### PR TITLE
Rewrite engine loop for sliding window and circuit breaker

### DIFF
--- a/brokers/base.py
+++ b/brokers/base.py
@@ -41,6 +41,17 @@ class BrokerBase(ABC):
     ) -> OrderResult: ...
 
     @abstractmethod
+    async def place_limit_order(
+        self, ticker: str, action: str,
+        qty: int, limit_price: float,
+        extended_hours: bool = True,
+        on_fill: Optional[Callable] = None
+    ) -> OrderResult: ...
+
+    @abstractmethod
+    def subscribe_to_fill(self, order_id: str, callback: Callable): ...
+
+    @abstractmethod
     async def cancel_order(self, order_id: str) -> bool: ...
 
     @abstractmethod

--- a/brokers/ibkr/adapter.py
+++ b/brokers/ibkr/adapter.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from typing import Optional, Callable
-from ib_insync import IB, Stock, Order, Trade
+from ib_insync import IB, Stock, Order, Trade, LimitOrder
 
 from brokers.base import BrokerBase, OrderResult
 from brokers.ibkr.connection import async_connect
@@ -95,16 +95,33 @@ class IBKRAdapter(BrokerBase):
         finally:
             self.ib.cancelMktData(contract)
 
-    async def place_limit_order(self, ticker: str, action: str, qty: int, limit_price: float,
-                                 on_fill: Optional[Callable] = None) -> OrderResult:
-        """
-        Implementation of place_limit_order as requested in the PR.
-        This calls order_builder and submits via ib.placeOrder.
-        For this bot, limit orders are always brackets. We use a 1% profit target as default
-        if not otherwise specified, though usually place_bracket_order will be used.
-        """
-        profit_price = limit_price * 1.01 if action == 'BUY' else limit_price * 0.99
-        return await self.place_bracket_order(ticker, action, qty, limit_price, profit_price, on_fill=on_fill)
+    async def place_limit_order(
+        self, ticker: str, action: str,
+        qty: int, limit_price: float,
+        extended_hours: bool = True,
+        on_fill: Optional[Callable] = None
+    ) -> OrderResult:
+        from brokers.ibkr.order_builder import get_dynamic_exchange
+        exchange = get_dynamic_exchange()
+        contract = Stock(ticker, exchange, 'USD')
+        await self.ib.qualifyContractsAsync(contract)
+
+        order = LimitOrder(action, qty, limit_price)
+        order.tif = 'GTC'
+        order.outsideRth = extended_hours
+
+        self.ib.placeOrder(contract, order)
+
+        if on_fill:
+            self._on_fill_callbacks[str(order.orderId)] = on_fill
+
+        return OrderResult(
+            order_id=str(order.orderId),
+            status='submitted'
+        )
+
+    def subscribe_to_fill(self, order_id: str, callback: Callable):
+        self._on_fill_callbacks[order_id] = callback
 
     async def place_bracket_order(
         self, ticker: str, action: str,

--- a/config/schema.py
+++ b/config/schema.py
@@ -10,7 +10,7 @@ class AppConfig(BaseModel):
     ibkr_client_id: int = Field(default=1)
     ibkr_username: Optional[str] = Field(default=None)
     ibkr_password: Optional[str] = Field(default=None)
-    poll_interval_seconds: int = Field(default=10)
+    poll_interval_seconds: int = Field(default=60)
     max_spread_pct: float = Field(default=0.5)
     google_sheet_id: str
     google_credentials_json: str

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -116,122 +116,97 @@ class GridEngine:
         # 0. Watchdog: ensure connection
         await self.broker.ensure_connected()
 
-        # 1. Refresh grid periodically
-        if (datetime.now() - self._last_grid_refresh).total_seconds() > 900: # 15 mins
-            logger.info("Refreshing grid state from sheet")
-            self.grid_state = await self.sheet.fetch_grid()
-            self._last_grid_refresh = datetime.now()
-
+        # 1. Always Refresh grid from sheet
+        self.grid_state = await self.sheet.fetch_grid()
         if not self.grid_state:
             return
 
-        # 2. Reconcile orders periodically
-        if (datetime.now() - self._last_reconciliation).total_seconds() > 60: # 1 min
-            await self._reconcile_orders()
-            self._last_reconciliation = datetime.now()
+        # 2. Circuit Breaker
+        positions = await self.broker.get_positions()
+        broker_shares = positions.get(TICKER, 0)
+        sheet_shares = sum(row.shares for row in self.grid_state.rows.values() if row.has_y)
 
-        # 3. Get market data
-        try:
-            bid, ask = await self.broker.get_bid_ask(TICKER)
-            price = (bid + ask) / 2 # Use mid-price for trigger check
-            self.last_price = price
-        except Exception as e:
-            logger.warning(f"Failed to get market data: {e}")
+        if broker_shares != sheet_shares:
+            msg = f"CIRCUIT BREAKER: Share discrepancy. Broker: {broker_shares}, Sheet: {sheet_shares}. Halting cycle."
+            logger.critical(msg)
+            await self.sheet.log_error(msg)
             return
 
-        # 4. Spread Guard check
-        if self.spread_guard.is_too_wide(bid, ask):
-            return
+        # 3. Calculate Window
+        distal_y = self.grid_state.distal_y_row
+        window_start = max(7, distal_y - 3)
+        window_end = max(7, distal_y + 3)
+        window_range = range(window_start, window_end + 1)
 
-        # 5. Check triggers
-        await self._check_triggers(price)
+        # 4. Get current open orders for evaluation
+        open_orders = await self.broker.get_open_orders()
+        broker_order_ids = {o['order_id'] for o in open_orders}
 
-    async def _reconcile_orders(self):
-        logger.debug("Reconciling orders with broker")
-        try:
-            open_orders = await self.broker.get_open_orders()
-            broker_order_ids = {o['order_id'] for o in open_orders}
-            tracked_order_ids = self.order_manager.get_tracked_order_ids()
-
-            # 1. Clear tracked orders that no longer exist at broker
-            for oid in tracked_order_ids:
-                if oid not in broker_order_ids:
-                    logger.warning(f"Order {oid} tracked but not found at broker. Marking cancelled for safety.")
-                    self.order_manager.mark_cancelled(oid)
-
-            # 2. Re-track orders found at broker that are NOT in OrderManager
-            # This handles self-healing after bot restart.
-            for order in open_orders:
-                oid = order['order_id']
-                if oid not in tracked_order_ids:
-                    self._retrack_broker_order(order)
-
-        except Exception as e:
-            logger.error(f"Reconciliation failed: {e}")
-
-    def _retrack_broker_order(self, order: dict):
-        """Attempts to match an orphan broker order to a grid level."""
-        oid = order['order_id']
-        price = order['limit_price']
-        qty = order['qty']
-        action = order['action']
-
-        # Look for a matching level in grid_state
+        # 5. Grid Evaluation
         for row in self.grid_state.rows.values():
-            limit_price = row.buy_price if action == 'BUY' else row.sell_price
-            if limit_price == price and row.shares == qty:
-                # Found a match. Retrack it.
-                logger.info(f"Retracking orphan broker order {oid} to grid row {row.row_index}")
-                self.order_manager.track(row.row_index, OrderResult(order_id=oid, status='submitted'), action)
-                return
+            in_window = row.row_index in window_range
 
-    async def _check_triggers(self, current_price: float):
-        for row in self.grid_state.rows.values():
-            # In legacy v4, status "Working" often meant an order was already out.
-            # But we'll rely on our OrderManager for absolute truth of this session.
+            # Parse existing status to check for current orders and historical IDs
+            status_parts = row.status.split('|')
+            active_order_id = None
+            owned_id = None
+            for part in status_parts:
+                if part.startswith("WORKING_SELL:") or part.startswith("WORKING_BUY:"):
+                    active_order_id = part.split(":")[1]
+                elif part.startswith("OWNED:"):
+                    owned_id = part.split(":")[1]
 
-            # Buy check: if status is empty/ready and we don't have an open buy
-            # In some v4 variants, price < buy_price triggers it.
-            # Let's assume: if status is "Ready" (or similar) or we use the 'has_y' as an additional filter.
-            # The prompt says: "fetch_grid() should read cols C through H (rows 7 to 100), evaluating has_y if the string 'Y' is present in Column D."
-            # Usually 'Y' in Column D (Strategy) means this row is active for the current strategy.
+            # If an order is in Column C but not tracked, subscribe/track it
+            if active_order_id and active_order_id in broker_order_ids:
+                if not self.order_manager.is_tracked(active_order_id):
+                    logger.info(f"Re-tracking order {active_order_id} from sheet status for row {row.row_index}")
+                    action = 'SELL' if "WORKING_SELL" in row.status else 'BUY'
+                    self.broker.subscribe_to_fill(active_order_id, self._on_fill)
+                    self.order_manager.track(row.row_index, OrderResult(order_id=active_order_id, status='submitted'), action)
 
-            if not row.has_y:
-                continue
+            if in_window:
+                if row.has_y:
+                    # Expect active SELL order
+                    if not self.order_manager.has_open_sell(row.row_index):
+                        logger.info(f"Placing missing SELL for owned row {row.row_index}")
+                        result = await self.broker.place_limit_order(
+                            ticker=TICKER, action='SELL', qty=row.shares,
+                            limit_price=row.sell_price, on_fill=self._on_fill
+                        )
+                        if result.status == 'submitted':
+                            self.order_manager.track(row.row_index, result, 'SELL')
+                            new_status = f"WORKING_SELL:{result.order_id}"
+                            if owned_id: new_status += f"|OWNED:{owned_id}"
+                            await self.sheet.update_row_status(row.row_index, new_status)
+                elif row.row_index > distal_y:
+                    # Expect active BUY order
+                    if not self.order_manager.has_open_buy(row.row_index):
+                        logger.info(f"Placing missing BUY for empty row {row.row_index}")
+                        result = await self.broker.place_limit_order(
+                            ticker=TICKER, action='BUY', qty=row.shares,
+                            limit_price=row.buy_price, on_fill=self._on_fill
+                        )
+                        if result.status == 'submitted':
+                            self.order_manager.track(row.row_index, result, 'BUY')
+                            await self.sheet.update_row_status(row.row_index, f"WORKING_BUY:{result.order_id}")
+            else:
+                # Outside window
+                # Cancel any active orders for this row
+                if row.row_index in self.order_manager._row_to_orders:
+                    oids = list(self.order_manager._row_to_orders[row.row_index])
+                    for oid in oids:
+                        logger.info(f"Cancelling order {oid} for row {row.row_index} (outside window)")
+                        await self.broker.cancel_order(oid)
+                        self.order_manager.mark_cancelled(oid)
 
-            # Buy Trigger
-            if current_price <= row.buy_price and not self.order_manager.has_open_buy(row.row_index) and row.status != "Filled":
-                # Calculate 1% profit target from buy_price
-                profit_price = round(row.buy_price * 1.01, 2)
-                logger.info(f"Triggered BUY for row {row.row_index} at price {current_price} (buy_price: {row.buy_price})")
-                result = await self.broker.place_bracket_order(
-                    ticker=TICKER,
-                    action='BUY',
-                    qty=row.shares,
-                    limit_price=row.buy_price,
-                    profit_price=profit_price,
-                    on_fill=self._on_fill
-                )
-                if result.status == 'submitted':
-                    self.order_manager.track(row.row_index, result, 'BUY')
-                    await self.sheet.update_row_status(row.row_index, "Working")
-
-            # Sell Trigger
-            if current_price >= row.sell_price and not self.order_manager.has_open_sell(row.row_index) and row.status != "Filled":
-                # Calculate 1% profit target
-                profit_price = round(row.sell_price * 0.99, 2)
-                logger.info(f"Triggered SELL for row {row.row_index} at price {current_price} (sell_price: {row.sell_price})")
-                result = await self.broker.place_bracket_order(
-                    ticker=TICKER,
-                    action='SELL',
-                    qty=row.shares,
-                    limit_price=row.sell_price,
-                    profit_price=profit_price,
-                    on_fill=self._on_fill
-                )
-                if result.status == 'submitted':
-                    self.order_manager.track(row.row_index, result, 'SELL')
-                    await self.sheet.update_row_status(row.row_index, "Working")
+                # Update status
+                if row.has_y:
+                    new_status = f"OWNED:{owned_id}" if owned_id else "OWNED"
+                    if row.status != new_status:
+                        await self.sheet.update_row_status(row.row_index, new_status)
+                else:
+                    if row.status != "IDLE":
+                        await self.sheet.update_row_status(row.row_index, "IDLE")
 
     def _on_fill(self, fill_details: dict):
         self.last_fill_time = datetime.now()
@@ -240,7 +215,12 @@ class GridEngine:
 
         if row_index:
             # Update status in sheet
-            asyncio.create_task(self.sheet.update_row_status(row_index, "Filled"))
+            if action == 'BUY':
+                new_status = f"OWNED:{order_id}"
+            else: # SELL
+                new_status = "IDLE"
+
+            asyncio.create_task(self.sheet.update_row_status(row_index, new_status))
 
             # Prepare data for sheet logging in Fills tab
             log_data = {

--- a/engine/order_manager.py
+++ b/engine/order_manager.py
@@ -60,3 +60,6 @@ class OrderManager:
 
     def get_tracked_order_ids(self) -> List[str]:
         return list(self._order_map.keys())
+
+    def is_tracked(self, order_id: str) -> bool:
+        return order_id in self._order_map

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,7 +22,7 @@ def test_default_values(tmp_path):
     assert config.ibkr_host == "127.0.0.1"
     assert config.ibkr_port == 7497
     assert config.ibkr_client_id == 1
-    assert config.poll_interval_seconds == 10
+    assert config.poll_interval_seconds == 60
     assert config.max_spread_pct == 0.5
     assert config.google_sheet_id == "test_sheet_id"
     assert config.google_credentials_json == "{}"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -17,7 +17,10 @@ def mock_broker():
     # mid = 100.0, spread = 0.1%
     broker.get_bid_ask = AsyncMock(return_value=(99.95, 100.05))
     broker.place_bracket_order = AsyncMock(return_value=OrderResult(order_id="ORD-P|ORD-T", status="submitted"))
+    broker.place_limit_order = AsyncMock(return_value=OrderResult(order_id="ORD-123", status="submitted"))
     broker.get_open_orders = AsyncMock(return_value=[])
+    broker.get_positions = AsyncMock(return_value={"TQQQ": 10})
+    broker.subscribe_to_fill = MagicMock()
     return broker
 
 @pytest.fixture
@@ -25,7 +28,8 @@ def mock_sheet():
     sheet = AsyncMock()
     grid_state = GridState(
         rows={
-            7: GridRow(row_index=7, status="Ready", has_y=True, sell_price=105.0, buy_price=100.0, shares=10)
+            7: GridRow(row_index=7, status="OWNED:OLD-ID", has_y=True, sell_price=105.0, buy_price=100.0, shares=10),
+            8: GridRow(row_index=8, status="IDLE", has_y=False, sell_price=110.0, buy_price=105.0, shares=10)
         }
     )
     sheet.fetch_grid = AsyncMock(return_value=grid_state)
@@ -45,70 +49,56 @@ def config():
     )
 
 @pytest.mark.asyncio
-async def test_engine_places_buy_bracket(mock_broker, mock_sheet, config):
+async def test_engine_places_sell_and_buy_limits(mock_broker, mock_sheet, config):
     engine = GridEngine(mock_broker, mock_sheet, config)
-    engine.grid_state = await mock_sheet.fetch_grid()
-    engine._last_grid_refresh = datetime.now()
+    # distal_y will be 7. Window [7, 10].
+    # Row 7 is has_y -> should place SELL.
+    # Row 8 is NOT has_y and 8 > 7 -> should place BUY.
 
-    # mid = 99.9 <= 100.0, spread = 0.2% <= 0.5%
-    mock_broker.get_bid_ask.return_value = (99.8, 100.0)
+    mock_broker.get_positions.return_value = {"TQQQ": 10} # Matches Row 7 shares
 
     await engine._tick()
 
-    mock_broker.place_bracket_order.assert_called_once()
-    # Should track both IDs
-    assert engine.order_manager.has_open_buy(7)
-    assert "ORD-P" in engine.order_manager.get_tracked_order_ids()
-    assert "ORD-T" in engine.order_manager.get_tracked_order_ids()
-    mock_sheet.update_row_status.assert_called_with(7, "Working")
+    # Should have called place_limit_order twice
+    assert mock_broker.place_limit_order.call_count == 2
+
+    # Check SELL for row 7
+    assert engine.order_manager.has_open_sell(7)
+    # Status should preserve OLD-ID: WORKING_SELL:ORD-123|OWNED:OLD-ID
+    mock_sheet.update_row_status.assert_any_call(7, "WORKING_SELL:ORD-123|OWNED:OLD-ID")
+
+    # Check BUY for row 8
+    assert engine.order_manager.has_open_buy(8)
+    mock_sheet.update_row_status.assert_any_call(8, "WORKING_BUY:ORD-123")
 
 @pytest.mark.asyncio
-async def test_overtrading_prevention_after_fill(mock_broker, mock_sheet, config):
+async def test_circuit_breaker_halts(mock_broker, mock_sheet, config):
     engine = GridEngine(mock_broker, mock_sheet, config)
-    engine.grid_state = await mock_sheet.fetch_grid()
-    engine._last_grid_refresh = datetime.now()
+    mock_broker.get_positions.return_value = {"TQQQ": 500} # Mismatch (should be 10)
 
-    # mid = 99.9, spread = 0.2%
-    mock_broker.get_bid_ask.return_value = (99.8, 100.0)
-
-    # 1. Place order
     await engine._tick()
-    assert mock_broker.place_bracket_order.call_count == 1
 
-    # 2. Parent leg fills
-    engine._on_fill({'order_id': 'ORD-P', 'price': 100.0, 'qty': 10})
-
-    # 3. Check if level is still busy (due to ORD-T)
-    assert engine.order_manager.has_open_buy(7)
-
-    # 4. Next tick should NOT place new order
-    await engine._tick()
-    assert mock_broker.place_bracket_order.call_count == 1
-
-    # 5. Take-profit leg fills
-    engine._on_fill({'order_id': 'ORD-T', 'price': 101.0, 'qty': 10})
-
-    # 6. Now level should be clear
-    assert not engine.order_manager.has_open_buy(7)
-
-    # 7. Next tick SHOULD place new order if price still in range
-    await engine._tick()
-    assert mock_broker.place_bracket_order.call_count == 2
+    # Should NOT place any orders
+    assert mock_broker.place_limit_order.call_count == 0
+    mock_sheet.log_error.assert_called()
 
 @pytest.mark.asyncio
-async def test_retrack_orphan_order(mock_broker, mock_sheet, config):
+async def test_retrack_from_status(mock_broker, mock_sheet, config):
+    # Mock row 8 as already having a working buy in status
+    grid_state = GridState(
+        rows={
+            7: GridRow(row_index=7, status="OWNED", has_y=True, sell_price=105.0, buy_price=100.0, shares=10),
+            8: GridRow(row_index=8, status="WORKING_BUY:ORD-EXISTING", has_y=False, sell_price=110.0, buy_price=105.0, shares=10)
+        }
+    )
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.get_positions.return_value = {"TQQQ": 10}
+    mock_broker.get_open_orders.return_value = [{'order_id': 'ORD-EXISTING', 'limit_price': 105.0, 'qty': 10, 'action': 'BUY'}]
+
     engine = GridEngine(mock_broker, mock_sheet, config)
-    engine.grid_state = await mock_sheet.fetch_grid()
+    await engine._tick()
 
-    # Mock an orphan order at broker
-    mock_broker.get_open_orders.return_value = [{
-        'order_id': 'ORD-ORPHAN',
-        'limit_price': 100.0,
-        'qty': 10,
-        'action': 'BUY'
-    }]
-
-    await engine._reconcile_orders()
-
-    assert engine.order_manager.has_open_buy(7)
-    assert "ORD-ORPHAN" in engine.order_manager.get_tracked_order_ids()
+    # Should NOT place new order for row 8
+    # But it should be tracked now
+    assert engine.order_manager.is_tracked("ORD-EXISTING")
+    assert engine.order_manager.has_open_buy(8)


### PR DESCRIPTION
This change refactors the core trading engine loop to use a sliding window approach for order management. It calculates an active window of 7 levels centered around the highest owned row (`distal_y_row`). Within this window, the bot ensures appropriate SELL or BUY limit orders are active. Outside the window, it cancels existing orders to maintain a clean state. 

A mathematical circuit breaker has been added to halt operations if there is a discrepancy between the total TQQQ shares reported by the broker and the sum of shares in the spreadsheet for "owned" rows. 

The bot now uses individual limit orders instead of bracket orders, allowing for more granular control over each grid level as the market moves and the window slides. Status strings in the spreadsheet are used to preserve historical order IDs and facilitate session recovery.

Fixes #14

---
*PR created automatically by Jules for task [3160285093463160242](https://jules.google.com/task/3160285093463160242) started by @Wakeboardsam*