### PR TITLE
Fix Dockerfile base image and Java package

### DIFF
--- a/tqqq_bot_v5/Dockerfile
+++ b/tqqq_bot_v5/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
-    openjdk-17-jre \
+    default-jre \
     supervisor \
     wget \
     unzip \


### PR DESCRIPTION
The Docker build for the Home Assistant Add-on was failing because `openjdk-17-jre` could not be found in the `python:3.11-slim` base image. This PR fixes the issue by pinning the base image to `python:3.11-slim-bookworm` and using the `default-jre` package instead. All unit tests passed after the change.

Fixes #18

---
*PR created automatically by Jules for task [18071644930281314106](https://jules.google.com/task/18071644930281314106) started by @Wakeboardsam*