### PR TITLE
Fix IB Gateway Crash and Configure Memory Limit

### DIFF
--- a/tqqq_bot_v5/Dockerfile
+++ b/tqqq_bot_v5/Dockerfile
@@ -23,6 +23,9 @@ RUN wget -q https://download2.interactivebrokers.com/installers/ibgateway/stable
     && ./ibgateway-stable-standalone-linux-x64.sh -q -dir /opt/ibgateway \
     && rm ibgateway-stable-standalone-linux-x64.sh
 
+# Configure IB Gateway memory limit
+RUN find /opt/ibgateway -name "*.vmoptions" -exec sh -c 'echo "-Xmx512m" >> "{}"' \;
+
 # Install IBC
 RUN wget -q https://github.com/IbcAlpha/IBC/releases/download/3.23.0/IBCLinux-3.23.0.zip \
     && mkdir -p /opt/ibc \

--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.0.1"
+version: "5.0.2"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:

--- a/tqqq_bot_v5/supervisord.conf
+++ b/tqqq_bot_v5/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/dev/null
 logfile_maxbytes=0
 
 [program:ibgateway]
-command=/opt/ibc/scripts/ibcstart.sh ibgateway -Xmx512M
+command=/opt/ibc/scripts/ibcstart.sh ibgateway
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
This change fixes the IB Gateway crash on boot. The IBC gatewaystart.sh script does not accept raw Java memory flags via the command line. The memory limit is now correctly configured by appending the -Xmx512m flag to the official .vmoptions files during the Docker build process. Additionally, the supervisor configuration was cleaned up, and the project version was incremented.

Fixes #20

---
*PR created automatically by Jules for task [5938522881102696464](https://jules.google.com/task/5938522881102696464) started by @Wakeboardsam*