### PR TITLE
Fix Docker build crash and advance version

### DIFF
--- a/tqqq_bot_v5/Dockerfile
+++ b/tqqq_bot_v5/Dockerfile
@@ -22,7 +22,7 @@ RUN wget -q https://download2.interactivebrokers.com/installers/ibgateway/stable
     && chmod +x ibgateway-stable-standalone-linux-x64.sh \
     && ./ibgateway-stable-standalone-linux-x64.sh -q -dir /root/Jts/ibgateway \
     && rm ibgateway-stable-standalone-linux-x64.sh
-RUN mv /root/Jts/ibgateway/* /root/Jts/ibgateway/9999
+RUN VERSION_DIR=$(dirname $(find /root/Jts -name jars -type d | head -n 1)) && ln -sfn $VERSION_DIR /root/Jts/ibgateway/9999
 
 # Configure IB Gateway memory limit
 RUN find /root/Jts/ibgateway -name "*.vmoptions" -exec sh -c 'echo "-Xmx512m" >> "{}"' \;

--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.0.3"
+version: "5.0.4"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:


### PR DESCRIPTION
The Docker build was failing because it tried to move files into a directory that didn't exist yet, or had an unpredictable name due to versioning. Instead of moving files, I implemented a robust command in the `Dockerfile` that finds the actual installation directory (containing the `jars` folder) and creates a symlink named `9999` to it. This matches what `supervisord.conf` expects. I also incremented the project version to `5.0.4` as requested. Tests were run and passed.

Fixes #24

---
*PR created automatically by Jules for task [6494190711216582627](https://jules.google.com/task/6494190711216582627) started by @Wakeboardsam*