### PR TITLE
Fix xterm & Virtual Display for IB Gateway

### DIFF
--- a/tqqq_bot_v5/Dockerfile
+++ b/tqqq_bot_v5/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && apt-get install -y \
     libxrender1 \
     libxi6 \
     gettext-base \
+    xvfb \
+    xterm \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.0.4"
+version: "5.0.5"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:

--- a/tqqq_bot_v5/supervisord.conf
+++ b/tqqq_bot_v5/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/dev/null
 logfile_maxbytes=0
 
 [program:ibgateway]
-command=/opt/ibc/gatewaystart.sh 9999 --tws-path=/root/Jts --tws-settings-path=/root/Jts
+command=xvfb-run --auto-servernum /opt/ibc/gatewaystart.sh 9999 -inline --tws-path=/root/Jts --tws-settings-path=/root/Jts
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
This change fixes the 'xterm: command not found' error and IB Gateway crashes by:
1. Installing `xvfb` and `xterm` in the Docker image.
2. Using `xvfb-run` to provide a virtual display for the headless Java environment.
3. Enabling the `-inline` flag for IBC to prevent it from attempting to spawn a new window.
4. Advancing the configuration version to 5.0.5.

Fixes #26

---
*PR created automatically by Jules for task [703802495429940190](https://jules.google.com/task/703802495429940190) started by @Wakeboardsam*