### PR TITLE
Fix Virtual Display Service by decoupling Xvfb

### DIFF
--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.0.5"
+version: "5.0.6"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:

--- a/tqqq_bot_v5/supervisord.conf
+++ b/tqqq_bot_v5/supervisord.conf
@@ -4,10 +4,18 @@ user=root
 logfile=/dev/null
 logfile_maxbytes=0
 
-[program:ibgateway]
-command=xvfb-run --auto-servernum /opt/ibc/gatewaystart.sh 9999 -inline --tws-path=/root/Jts --tws-settings-path=/root/Jts
+[program:xvfb]
+command=Xvfb :99 -ac -screen 0 1024x768x16
 autostart=true
 autorestart=true
+priority=10
+
+[program:ibgateway]
+environment=DISPLAY=":99"
+command=/opt/ibc/gatewaystart.sh 9999 -inline --tws-path=/root/Jts --tws-settings-path=/root/Jts
+autostart=true
+autorestart=true
+priority=20
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
This change fixes the xterm display error by decoupling Xvfb into its own permanent service in Supervisord. This ensures that the virtual display is properly initialized before the IB Gateway starts and avoids issues with the `xvfb-run` wrapper when running as root. The IB Gateway service now explicitly references the display via the `DISPLAY` environment variable. The configuration version has also been advanced to 5.0.6.

Fixes #28

---
*PR created automatically by Jules for task [6864744830627605037](https://jules.google.com/task/6864744830627605037) started by @Wakeboardsam*