### PR TITLE
Clean Boot Architecture: Move IB Gateway to run.sh

### DIFF
--- a/tqqq_bot_v5/Dockerfile
+++ b/tqqq_bot_v5/Dockerfile
@@ -23,6 +23,7 @@ RUN wget -q https://download2.interactivebrokers.com/installers/ibgateway/stable
     && chmod +x ibgateway-stable-standalone-linux-x64.sh \
     && ./ibgateway-stable-standalone-linux-x64.sh -q -dir /root/Jts/ibgateway \
     && rm ibgateway-stable-standalone-linux-x64.sh
+
 RUN VERSION_DIR=$(dirname $(find /root/Jts -name jars -type d | head -n 1)) && ln -sfn $VERSION_DIR /root/Jts/ibgateway/9999
 
 # Configure IB Gateway memory limit
@@ -42,7 +43,8 @@ RUN wget -q https://github.com/IbcAlpha/IBC/releases/download/3.23.0/IBCLinux-3.
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy application source code
+# Copy application source code and supervisord config
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY . .
 
 # Set entrypoint

--- a/tqqq_bot_v5/run.sh
+++ b/tqqq_bot_v5/run.sh
@@ -25,16 +25,15 @@ export TWS_PATH=/root/Jts
 export IBC_PATH=/opt/ibc
 export TWS_SETTINGS_PATH=/root/Jts
 
-# Wait for Gateway port before starting supervisord?
-# No, supervisord starts both. But we can use wait_for_gateway.py in botpy's command if needed.
-# However, the requirement said run.sh should render and then exec supervisord.
-# wait_for_gateway.py is called by run.sh? No, botpy has 30s delay.
-# Wait, the prompt says: "Create gateway/wait_for_gateway.py ... This is called by run.sh before starting the bot."
-# If I exec supervisord, it never returns. I should probably use it in botpy command or before exec supervisord if I don't use supervisord for gateway?
-# No, supervisord MUST run both.
+echo "Starting Xvfb..."
+Xvfb :99 -ac -screen 0 1024x768x16 &
+export DISPLAY=:99
 
-# Let's check the requirement again: "This is called by run.sh before starting the bot."
-# If supervisord manages both, I can't call it in run.sh before supervisord because gateway isn't running yet.
-# I'll modify the botpy command in supervisord.conf to call wait_for_gateway.py first.
+echo "Starting IB Gateway via IBC..."
+/opt/ibc/gatewaystart.sh 9999 -inline --tws-path=/root/Jts --tws-settings-path=/root/Jts --ibc-ini=/tmp/ibc_config.ini &
 
-exec /usr/bin/supervisord -c /app/supervisord.conf
+echo "Waiting 30 seconds for Gateway to initialize..."
+sleep 30
+
+echo "Starting Supervisord to launch Python Bot..."
+exec supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/tqqq_bot_v5/supervisord.conf
+++ b/tqqq_bot_v5/supervisord.conf
@@ -4,29 +4,11 @@ user=root
 logfile=/dev/null
 logfile_maxbytes=0
 
-[program:xvfb]
-command=Xvfb :99 -ac -screen 0 1024x768x16
-autostart=true
-autorestart=true
-priority=10
-
-[program:ibgateway]
-environment=DISPLAY=":99"
-command=/opt/ibc/gatewaystart.sh 9999 --tws-path=/root/Jts --tws-settings-path=/root/Jts --ibc-ini=/tmp/ibc_config.ini
-autostart=true
-autorestart=true
-priority=20
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-
 [program:botpy]
 command=bash -c "python3 /app/gateway/wait_for_gateway.py --port $IBKR_PORT && python3 /app/main.py"
 autostart=true
 autorestart=true
 startsecs=30
-depends_on=ibgateway
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
Stabilized the boot sequence by moving Xvfb and IB Gateway from Supervisord management to the entrypoint script (run.sh). This prevents process tracking issues in Supervisord that were causing restart loops, and ensures a controlled 30-second delay before the Python bot starts. Verified with full test suite passing.

Fixes #32

---
*PR created automatically by Jules for task [8536040836143696203](https://jules.google.com/task/8536040836143696203) started by @Wakeboardsam*