### PR TITLE
The Verified Sed Patch

### DIFF
--- a/tqqq_bot_v5/Dockerfile
+++ b/tqqq_bot_v5/Dockerfile
@@ -36,6 +36,9 @@ RUN wget -q https://github.com/IbcAlpha/IBC/releases/download/3.23.0/IBCLinux-3.
     && chmod +x /opt/ibc/scripts/*.sh /opt/ibc/*.sh 2>/dev/null || true \
     && rm IBCLinux-3.23.0.zip
 
+RUN sed -i 's/xterm.*-e //' /opt/ibc/gatewaystart.sh
+RUN ! grep -q "xterm" /opt/ibc/gatewaystart.sh
+
 # Configure IBC
 # Note: config is rendered at runtime by run.sh
 

--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.0.5"
+version: "5.0.6"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:


### PR DESCRIPTION
This change patches the IBC gatewaystart.sh script during the Docker build process to remove the xterm dependency. It also includes a strict verification step that will cause the build to fail if 'xterm' is still present in the script. The version has been bumped to 5.0.6 in config.yaml.

Fixes #34

---
*PR created automatically by Jules for task [18221338519644898733](https://jules.google.com/task/18221338519644898733) started by @Wakeboardsam*