### PR TITLE
Add IBC Diagnostic Logging and Version Bump

### DIFF
--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.0.6"
+version: "5.0.8"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:

--- a/tqqq_bot_v5/run.sh
+++ b/tqqq_bot_v5/run.sh
@@ -1,39 +1,30 @@
 #!/bin/bash
-set -e
-
-CONFIG_PATH="/data/options.json"
-
-# Extract credentials and mode using jq
-export IBKR_USERNAME=$(jq -r '.ibkr_username // empty' $CONFIG_PATH)
-export IBKR_PASSWORD=$(jq -r '.ibkr_password // empty' $CONFIG_PATH)
-PAPER_TRADING=$(jq -r '.paper_trading' $CONFIG_PATH)
-
-if [ "$PAPER_TRADING" = "true" ]; then
-    export TRADING_MODE="paper"
-    export IBKR_PORT=7497
-else
-    export TRADING_MODE="live"
-    export IBKR_PORT=7496
+echo "Parsing Home Assistant options..."
+IBKR_USER=$(jq -r '.ibkr_username // empty' /data/options.json)
+IBKR_PASS=$(jq -r '.ibkr_password // empty' /data/options.json)
+PAPER_FLAG=$(jq -r '.paper_trading' /data/options.json)
+TRADING_MODE="paper"
+if [ "$PAPER_FLAG" = "false" ]; then
+TRADING_MODE="live"
 fi
-
-# Render IBC config template
-cat /app/gateway/ibc_config.ini.template | envsubst > /tmp/ibc_config.ini
-
-# Export variables for IBC
-export IBC_INI=/tmp/ibc_config.ini
-export TWS_PATH=/root/Jts
-export IBC_PATH=/opt/ibc
-export TWS_SETTINGS_PATH=/root/Jts
-
+echo "Generating IBC config..."
+cat <<EOF > /tmp/ibc_config.ini
+IbLoginId=${IBKR_USER}
+IbPassword=${IBKR_PASS}
+TradingMode=${TRADING_MODE}
+IbDir=/root/Jts
+EOF
 echo "Starting Xvfb..."
 Xvfb :99 -ac -screen 0 1024x768x16 &
 export DISPLAY=:99
-
 echo "Starting IB Gateway via IBC..."
-/opt/ibc/gatewaystart.sh 9999 -inline --tws-path=/root/Jts --tws-settings-path=/root/Jts --ibc-ini=/tmp/ibc_config.ini &
-
+/opt/ibc/gatewaystart.sh 9999 -inline --tws-path=/root/Jts --tws-settings-path=/root/Jts --ibc-ini=/tmp/ibc_config.ini < /dev/null &
 echo "Waiting 30 seconds for Gateway to initialize..."
 sleep 30
-
+echo "=== SEARCHING FOR AND DUMPING IBC DIAGNOSTIC LOGS ==="
+cat /root/ibc/logs/*.txt 2>&1 || echo "No logs found at /root/ibc/logs/"
+echo "--- Searching alternate paths ---"
+find /root/ibc /opt/ibc /root/Jts -name "*.txt" -print -exec cat {} \; 2>/dev/null
+echo "====================================================="
 echo "Starting Supervisord to launch Python Bot..."
 exec supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
Updated the `run.sh` script to assist in troubleshooting IB Gateway initialization by forcefully locating and dumping IBC diagnostic logs. Corrected syntax errors in the provided script snippet to ensure functionality. Also updated the add-on version to 5.0.8.

Fixes #36

---
*PR created automatically by Jules for task [7383480083041893262](https://jules.google.com/task/7383480083041893262) started by @Wakeboardsam*