### PR TITLE
Fix Bot Startup Command and Clean Up Logs

### DIFF
--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.0.8"
+version: "5.0.9"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:

--- a/tqqq_bot_v5/run.sh
+++ b/tqqq_bot_v5/run.sh
@@ -21,10 +21,8 @@ echo "Starting IB Gateway via IBC..."
 /opt/ibc/gatewaystart.sh 9999 -inline --tws-path=/root/Jts --tws-settings-path=/root/Jts --ibc-ini=/tmp/ibc_config.ini < /dev/null &
 echo "Waiting 30 seconds for Gateway to initialize..."
 sleep 30
-echo "=== SEARCHING FOR AND DUMPING IBC DIAGNOSTIC LOGS ==="
-cat /root/ibc/logs/*.txt 2>&1 || echo "No logs found at /root/ibc/logs/"
-echo "--- Searching alternate paths ---"
-find /root/ibc /opt/ibc /root/Jts -name "*.txt" -print -exec cat {} \; 2>/dev/null
-echo "====================================================="
+echo "=== IBC DIAGNOSTIC LOGS ==="
+cat /root/ibc/logs/*.txt 2>/dev/null || echo "No IBC logs found."
+echo "==========================="
 echo "Starting Supervisord to launch Python Bot..."
 exec supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/tqqq_bot_v5/supervisord.conf
+++ b/tqqq_bot_v5/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/dev/null
 logfile_maxbytes=0
 
 [program:botpy]
-command=bash -c "python3 /app/gateway/wait_for_gateway.py --port $IBKR_PORT && python3 /app/main.py"
+command=bash -c "python3 /app/gateway/wait_for_gateway.py --port 7497 && python3 /app/main.py"
 autostart=true
 autorestart=true
 startsecs=30


### PR DESCRIPTION
This change fixes the bot startup sequence by ensuring the `wait_for_gateway.py` script receives an explicit port argument (7497) in the supervisor configuration, preventing immediate crashes. Additionally, it cleans up the `run.sh` script by replacing an aggressive `find` command with a simplified log dump and bumps the add-on version to 5.0.9.

Fixes #38

---
*PR created automatically by Jules for task [7637770104897309482](https://jules.google.com/task/7637770104897309482) started by @Wakeboardsam*