### PR TITLE
Extend API Timeout to 300s

### DIFF
--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.1.0"
+version: "5.1.1"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:

--- a/tqqq_bot_v5/gateway/wait_for_gateway.py
+++ b/tqqq_bot_v5/gateway/wait_for_gateway.py
@@ -3,7 +3,7 @@ import time
 import sys
 import argparse
 
-def wait_for_port(port, host='localhost', timeout=120):
+def wait_for_port(port, host='localhost', timeout=300):
     start_time = time.time()
     while True:
         try:
@@ -20,7 +20,7 @@ def wait_for_port(port, host='localhost', timeout=120):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Wait for IB Gateway to be ready.')
     parser.add_argument('--port', type=int, default=7497, help='Port to poll (default: 7497)')
-    parser.add_argument('--timeout', type=int, default=120, help='Max timeout in seconds (default: 120)')
+    parser.add_argument('--timeout', type=int, default=300, help='Max timeout in seconds (default: 300)')
     args = parser.parse_args()
 
     if not wait_for_port(args.port, timeout=args.timeout):

--- a/tqqq_bot_v5/supervisord.conf
+++ b/tqqq_bot_v5/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/dev/null
 logfile_maxbytes=0
 
 [program:botpy]
-command=bash -c "python gateway/wait_for_gateway.py --port 7497 && python main.py"
+command=bash -c "python gateway/wait_for_gateway.py --port 7497 --timeout 300 && python main.py"
 autostart=true
 autorestart=true
 startsecs=30


### PR DESCRIPTION
This change increases the timeout for the IB Gateway readiness check from 120 seconds to 300 seconds. This ensures that the bot does not time out while the IB Gateway is still opening its API port (7497). The change is applied to the supervisord configuration, the wait script's defaults, and the addon version is bumped to 5.1.1.

Fixes #42

---
*PR created automatically by Jules for task [6227785399863607689](https://jules.google.com/task/6227785399863607689) started by @Wakeboardsam*