### PR TITLE
Force API Port and Bypass Dialogs

### DIFF
--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.1.1"
+version: "5.1.2"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:

--- a/tqqq_bot_v5/run.sh
+++ b/tqqq_bot_v5/run.sh
@@ -14,6 +14,10 @@ IbLoginId=${IBKR_USER}
 IbPassword=${IBKR_PASS}
 TradingMode=${TRADING_MODE}
 IbDir=/root/Jts
+ReadOnlyApi=no
+OverrideTwsApiPort=7497
+AcceptIncomingConnectionAction=accept
+AcceptNonBrokerageAccountWarning=yes
 EOF
 echo "Starting Xvfb..."
 Xvfb :99 -ac -screen 0 1024x768x16 &


### PR DESCRIPTION
This change updates the IBC configuration in `run.sh` to ensure the IB Gateway API port is forced to 7497 and all incoming connection and account warning dialogs are automatically accepted. This prevents the bot from being blocked by hidden confirmation dialogs in headless environments. Additionally, the add-on version is bumped to 5.1.2.

Fixes #44

---
*PR created automatically by Jules for task [3105993319330749933](https://jules.google.com/task/3105993319330749933) started by @Wakeboardsam*