### PR TITLE
Fix Async Warning and Bump Version

### DIFF
--- a/tqqq_bot_v5/brokers/ibkr/adapter.py
+++ b/tqqq_bot_v5/brokers/ibkr/adapter.py
@@ -31,7 +31,7 @@ class IBKRAdapter(BrokerBase):
         return self.ib.isConnected()
 
     async def ensure_connected(self):
-        if not self.is_connected():
+        if not await self.is_connected():
             logger.warning("IBKR disconnected. Watchdog attempting reconnection...")
             # Implement exponential backoff for reconnection as requested
             delay = 5
@@ -44,7 +44,7 @@ class IBKRAdapter(BrokerBase):
                         self.ib.connectAsync(self.host, self.port, clientId=self.client_id),
                         timeout=30
                     )
-                    if self.is_connected():
+                    if await self.is_connected():
                         logger.info("Watchdog successfully reconnected.")
                         return
                 except Exception as e:

--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.1.2"
+version: "5.1.3"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:

--- a/tqqq_bot_v5/tests/test_is_connected_await.py
+++ b/tqqq_bot_v5/tests/test_is_connected_await.py
@@ -1,0 +1,30 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from brokers.ibkr.adapter import IBKRAdapter
+
+@pytest.mark.asyncio
+async def test_ensure_connected_awaits_is_connected():
+    adapter = IBKRAdapter(host='localhost', port=7497, client_id=1, paper=True)
+    adapter.ib = MagicMock()
+
+    # Mock is_connected to return True immediately to avoid the retry loop
+    adapter.is_connected = AsyncMock(return_value=True)
+
+    await adapter.ensure_connected()
+
+    # If it wasn't awaited, this would fail or throw a warning
+    adapter.is_connected.assert_awaited()
+
+@pytest.mark.asyncio
+async def test_ensure_connected_reconnects_and_awaits():
+    adapter = IBKRAdapter(host='localhost', port=7497, client_id=1, paper=True)
+    adapter.ib = MagicMock()
+
+    # First call False, second call True
+    adapter.is_connected = AsyncMock(side_effect=[False, True])
+    adapter.ib.connectAsync = AsyncMock()
+
+    await adapter.ensure_connected()
+
+    assert adapter.is_connected.await_count == 2
+    adapter.ib.connectAsync.assert_awaited_once()


### PR DESCRIPTION
Fixed the 'never awaited' RuntimeWarning in the IBKR adapter by adding the `await` keyword to calls of the `is_connected()` coroutine within `ensure_connected()`. Also updated the bot version to 5.1.3 in `config.yaml` and added a specific test case to ensure these calls remain properly awaited in the future.

Fixes #46

---
*PR created automatically by Jules for task [554905095869420212](https://jules.google.com/task/554905095869420212) started by @Wakeboardsam*