### PR TITLE
Fix Wallet Parsing & Order Duration (v5.1.5)

### DIFF
--- a/tqqq_bot_v5/brokers/base.py
+++ b/tqqq_bot_v5/brokers/base.py
@@ -33,6 +33,9 @@ class BrokerBase(ABC):
     async def get_bid_ask(self, ticker: str) -> tuple[float, float]: ...
 
     @abstractmethod
+    async def get_wallet_balance(self) -> float: ...
+
+    @abstractmethod
     async def place_bracket_order(
         self, ticker: str, action: str,  # 'BUY' | 'SELL'
         qty: int, limit_price: float, profit_price: float,

--- a/tqqq_bot_v5/brokers/ibkr/adapter.py
+++ b/tqqq_bot_v5/brokers/ibkr/adapter.py
@@ -95,6 +95,15 @@ class IBKRAdapter(BrokerBase):
         finally:
             self.ib.cancelMktData(contract)
 
+    async def get_wallet_balance(self) -> float:
+        """
+        Returns the USD AvailableFunds from the account.
+        """
+        for val in self.ib.accountValues():
+            if val.tag == 'AvailableFunds' and val.currency == 'USD':
+                return float(val.value)
+        return 0.0
+
     async def place_limit_order(
         self, ticker: str, action: str,
         qty: int, limit_price: float,
@@ -108,7 +117,7 @@ class IBKRAdapter(BrokerBase):
 
         order = LimitOrder(action, qty, limit_price)
         order.tif = 'GTC'
-        order.outsideRth = extended_hours
+        order.outsideRth = True
 
         self.ib.placeOrder(contract, order)
 
@@ -180,7 +189,8 @@ class IBKRAdapter(BrokerBase):
         return positions
 
     def _on_order_status(self, trade: Trade):
-        if trade.orderStatus.status == 'Filled':
+        status = trade.orderStatus.status
+        if status == 'Filled':
             order_id = str(trade.order.orderId)
             callback = self._on_fill_callbacks.get(order_id)
             if callback:
@@ -195,3 +205,14 @@ class IBKRAdapter(BrokerBase):
                 logger.info(f"Fill callback called for order {order_id}")
                 # Optional: remove callback after fill if it's a one-time thing
                 # del self._on_fill_callbacks[order_id]
+        elif status in ('Cancelled', 'Inactive', 'Rejected'):
+            reason = trade.orderStatus.whyHeld or "No reason provided"
+            logger.warning(
+                f"\n"
+                f"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+                f"LOUD ALERT: ORDER {trade.order.orderId} {status.upper()}!\n"
+                f"Ticker: {trade.contract.symbol}\n"
+                f"Action: {trade.order.action}\n"
+                f"Reason: {reason}\n"
+                f"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+            )

--- a/tqqq_bot_v5/brokers/schwab/adapter.py
+++ b/tqqq_bot_v5/brokers/schwab/adapter.py
@@ -21,6 +21,9 @@ class SchwabAdapter(BrokerBase):
     async def get_bid_ask(self, ticker: str) -> tuple[float, float]:
         raise NotImplementedError
 
+    async def get_wallet_balance(self) -> float:
+        raise NotImplementedError
+
     async def place_bracket_order(
         self, ticker: str, action: str,
         qty: int, limit_price: float, profit_price: float,
@@ -33,6 +36,17 @@ class SchwabAdapter(BrokerBase):
         raise NotImplementedError
 
     async def get_open_orders(self) -> list[dict]:
+        raise NotImplementedError
+
+    async def place_limit_order(
+        self, ticker: str, action: str,
+        qty: int, limit_price: float,
+        extended_hours: bool = True,
+        on_fill: Optional[Callable] = None
+    ) -> OrderResult:
+        raise NotImplementedError
+
+    def subscribe_to_fill(self, order_id: str, callback: Callable):
         raise NotImplementedError
 
     async def get_positions(self) -> dict[str, int]:

--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.1.3"
+version: "5.1.5"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:

--- a/tqqq_bot_v5/tests/test_ibkr_adapter.py
+++ b/tqqq_bot_v5/tests/test_ibkr_adapter.py
@@ -138,3 +138,44 @@ async def test_market_data_cancellation(mock_ib):
     assert price == 50.0
     mock_ib.reqMktData.assert_called_once()
     mock_ib.cancelMktData.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_get_wallet_balance(mock_ib):
+    adapter = IBKRAdapter(host='localhost', port=7497, client_id=1, paper=True)
+    adapter.ib = mock_ib
+
+    # Mock accountValues
+    val1 = MagicMock()
+    val1.tag = 'NetLiquidation'
+    val1.value = '1000.0'
+    val1.currency = 'USD'
+
+    val2 = MagicMock()
+    val2.tag = 'AvailableFunds'
+    val2.value = '500.0'
+    val2.currency = 'USD'
+
+    val3 = MagicMock()
+    val3.tag = 'AvailableFunds'
+    val3.value = '100.0'
+    val3.currency = 'EUR'
+
+    mock_ib.accountValues.return_value = [val1, val2, val3]
+
+    balance = await adapter.get_wallet_balance()
+    assert balance == 500.0
+
+@pytest.mark.asyncio
+async def test_place_limit_order_outside_rth(mock_ib):
+    adapter = IBKRAdapter(host='localhost', port=7497, client_id=1, paper=True)
+    adapter.ib = mock_ib
+
+    with patch('brokers.ibkr.order_builder.get_dynamic_exchange', return_value='SMART'):
+        await adapter.place_limit_order('TQQQ', 'BUY', 10, 50.0)
+
+        # Get the order passed to placeOrder
+        args, kwargs = mock_ib.placeOrder.call_args
+        order = args[1]
+
+        assert order.outsideRth is True
+        assert order.tif == 'GTC'


### PR DESCRIPTION
This submission fixes several issues in the TQQQ bot:
1.  **Wallet Parsing**: The bot now correctly identifies the USD AvailableFunds from IBKR account values, avoiding incorrect balance reporting.
2.  **Order Duration**: Single limit orders are now explicitly set to Good 'Til Canceled (GTC) and Outside Regular Trading Hours (OutsideRTH), preventing rejections during market close.
3.  **Visibility**: Added loud logging alerts for order rejections and cancellations to facilitate troubleshooting.
4.  **Version Update**: Bumped the project version to 5.1.5.
5.  **Tests**: Added new unit tests in `test_ibkr_adapter.py` to verify the new functionality and ensure regressions are prevented.

Fixes #48

---
*PR created automatically by Jules for task [10146563997358580103](https://jules.google.com/task/10146563997358580103) started by @Wakeboardsam*