### PR TITLE
Add diagnostic logging and bump version to 5.1.7

### DIFF
--- a/tqqq_bot_v5/brokers/ibkr/adapter.py
+++ b/tqqq_bot_v5/brokers/ibkr/adapter.py
@@ -62,10 +62,11 @@ class IBKRAdapter(BrokerBase):
         contract = Stock(ticker, 'SMART', 'USD')
         await self.ib.qualifyContractsAsync(contract)
 
-        # Request market data
-        ticker_data = self.ib.reqMktData(contract, '', False, False)
-
         try:
+            # Request market data
+            ticker_data = self.ib.reqMktData(contract, '', False, False)
+            logger.info(f"Raw price response: {ticker_data}")
+
             # Wait for price to be available (briefly)
             for _ in range(50): # up to 5 seconds
                 if ticker_data.last > 0:
@@ -76,7 +77,12 @@ class IBKRAdapter(BrokerBase):
             if ticker_data.close > 0:
                 return ticker_data.close
 
+            logger.error("API call returned empty — possible Gateway auth or subscription issue")
             raise RuntimeError(f"Could not get price for {ticker}")
+        except Exception as e:
+            if not isinstance(e, RuntimeError):
+                logger.error(f"Error fetching price: {e}")
+            raise
         finally:
             self.ib.cancelMktData(contract)
 
@@ -99,10 +105,23 @@ class IBKRAdapter(BrokerBase):
         """
         Returns the USD AvailableFunds from the account.
         """
-        for val in self.ib.accountValues():
-            if val.tag == 'AvailableFunds' and val.currency == 'USD':
-                return float(val.value)
-        return 0.0
+        try:
+            response = self.ib.accountValues()
+            logger.info(f"Raw balance response: {response}")
+            if not response:
+                logger.error("API call returned empty — possible Gateway auth or subscription issue")
+                return 0.0
+
+            for val in response:
+                if val.tag == 'AvailableFunds' and val.currency == 'USD':
+                    return float(val.value)
+
+            logger.error("API call returned empty — possible Gateway auth or subscription issue")
+            return 0.0
+        except Exception as e:
+            logger.error(f"Error fetching balance: {e}")
+            logger.error("API call returned empty — possible Gateway auth or subscription issue")
+            return 0.0
 
     async def place_limit_order(
         self, ticker: str, action: str,

--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.1.5"
+version: "5.1.7"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:

--- a/tqqq_bot_v5/engine/engine.py
+++ b/tqqq_bot_v5/engine/engine.py
@@ -116,6 +116,17 @@ class GridEngine:
         # 0. Watchdog: ensure connection
         await self.broker.ensure_connected()
 
+        # 0.1 Diagnostic: fetch balance and price
+        try:
+            balance = await self.broker.get_wallet_balance()
+            price = await self.broker.get_price(TICKER)
+            self.last_price = price
+            if balance == 0 or price == 0:
+                logger.error("API call returned empty — possible Gateway auth or subscription issue")
+        except Exception as e:
+            logger.error(f"Diagnostic API call failed: {e}")
+            logger.error("API call returned empty — possible Gateway auth or subscription issue")
+
         # 1. Always Refresh grid from sheet
         self.grid_state = await self.sheet.fetch_grid()
         if not self.grid_state:


### PR DESCRIPTION
Add diagnostic logging to expose why wallet balance and ticker price are returning 0.
In the bot's main cycle, immediately after every IBKR API call (balance fetch, price fetch), add explicit try/except blocks that log the full raw response, not just the parsed value. Specifically:
- Log the raw API response object before parsing the balance.
- Log the raw price response for TQQQ.
- If either returns None, 0, or an empty object, log logger.error("API call returned empty — possible Gateway auth or subscription issue").
- Bump to 5.1.7.

Fixes #50

---
*PR created automatically by Jules for task [7510485003758675274](https://jules.google.com/task/7510485003758675274) started by @Wakeboardsam*