### PR TITLE
Fix IBKR adapter balance and price fetching

### DIFF
--- a/tqqq_bot_v5/brokers/ibkr/adapter.py
+++ b/tqqq_bot_v5/brokers/ibkr/adapter.py
@@ -71,15 +71,15 @@ class IBKRAdapter(BrokerBase):
             ticker_data = self.ib.reqMktData(contract, '', False, False)
             logger.info(f"Raw price response: {ticker_data}")
 
-            # Wait for price to be available (briefly)
-            for _ in range(50): # up to 5 seconds
-                if ticker_data.last > 0:
-                    return ticker_data.last
-                await asyncio.sleep(0.1)
+            # Wait for price to be available
+            await asyncio.sleep(2)
 
-            # Fallback to close price if last is not available
+            if ticker_data.last > 0:
+                return ticker_data.last
             if ticker_data.close > 0:
                 return ticker_data.close
+            if ticker_data.delayedLast > 0:
+                return ticker_data.delayedLast
 
             logger.error("API call returned empty — possible Gateway auth or subscription issue")
             raise RuntimeError(f"Could not get price for {ticker}")
@@ -110,7 +110,7 @@ class IBKRAdapter(BrokerBase):
         Returns the USD TotalCashValue or TotalCashBalance from the account.
         """
         try:
-            account_values = await self.ib.accountValuesAsync()
+            account_values = self.ib.accountValues()
             logger.info(f"Raw balance response: {account_values}")
             balance = next((float(v.value) for v in account_values if v.tag == 'TotalCashValue' and v.currency == 'USD'), 0.0)
 

--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.2.0"
+version: "5.2.1"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:

--- a/tqqq_bot_v5/tests/test_ibkr_adapter.py
+++ b/tqqq_bot_v5/tests/test_ibkr_adapter.py
@@ -130,6 +130,8 @@ async def test_market_data_cancellation(mock_ib):
     # Mock reqMktData to return a ticker with last price
     mock_ticker = MagicMock()
     mock_ticker.last = 50.0
+    mock_ticker.close = 0.0
+    mock_ticker.delayedLast = 0.0
     mock_ib.reqMktData.return_value = mock_ticker
     mock_ib.cancelMktData = MagicMock()
 
@@ -140,11 +142,34 @@ async def test_market_data_cancellation(mock_ib):
     mock_ib.cancelMktData.assert_called_once()
 
 @pytest.mark.asyncio
+async def test_get_price_fallbacks(mock_ib):
+    adapter = IBKRAdapter(host='localhost', port=7497, client_id=1, paper=True)
+    adapter.ib = mock_ib
+
+    # Test close fallback
+    mock_ticker = MagicMock()
+    mock_ticker.last = 0.0
+    mock_ticker.close = 51.0
+    mock_ticker.delayedLast = 0.0
+    mock_ib.reqMktData.return_value = mock_ticker
+
+    price = await adapter.get_price('TQQQ')
+    assert price == 51.0
+
+    # Test delayedLast fallback
+    mock_ticker.last = 0.0
+    mock_ticker.close = 0.0
+    mock_ticker.delayedLast = 52.0
+
+    price = await adapter.get_price('TQQQ')
+    assert price == 52.0
+
+@pytest.mark.asyncio
 async def test_get_wallet_balance(mock_ib):
     adapter = IBKRAdapter(host='localhost', port=7497, client_id=1, paper=True)
     adapter.ib = mock_ib
 
-    # Mock accountValuesAsync
+    # Mock accountValues
     val1 = MagicMock()
     val1.tag = 'NetLiquidation'
     val1.value = '1000.0'
@@ -160,7 +185,7 @@ async def test_get_wallet_balance(mock_ib):
     val3.value = '100.0'
     val3.currency = 'EUR'
 
-    mock_ib.accountValuesAsync = AsyncMock(return_value=[val1, val2, val3])
+    mock_ib.accountValues = MagicMock(return_value=[val1, val2, val3])
 
     balance = await adapter.get_wallet_balance()
     assert balance == 500.0


### PR DESCRIPTION
This submission fixes issues with fetching real numbers for account balance and market price in the IBKR adapter. 

Key changes:
1.  **Balance Fetching**: Replaced the asynchronous `accountValuesAsync()` with the synchronous `accountValues()` in `IBKRAdapter.get_wallet_balance`.
2.  **Price Fetching**: Improved `IBKRAdapter.get_price` by adding a mandatory 2-second sleep after requesting market data and implementing a tiered check for price fields (`last` -> `close` -> `delayedLast`).
3.  **Version Update**: Incremented the project version to `5.2.1` in `config.yaml`.
4.  **Testing**: Updated `tests/test_ibkr_adapter.py` to match the new synchronous balance retrieval and added a new test case `test_get_price_fallbacks` to verify the price retrieval priority logic. All tests passed.

Fixes #58

---
*PR created automatically by Jules for task [4752876790941904729](https://jules.google.com/task/4752876790941904729) started by @Wakeboardsam*