### PR TITLE
PR 3 — Restore V4 dashboard behavior (Cash Balance in C2)

### DIFF
--- a/tqqq_bot_v5/engine/engine.py
+++ b/tqqq_bot_v5/engine/engine.py
@@ -135,6 +135,7 @@ class GridEngine:
         # 0.1 Diagnostic: fetch balance and price
         try:
             balance = await self.broker.get_wallet_balance()
+            await self.sheet.write_cash_value(balance)
             price = await self.broker.get_price(TICKER)
             self.last_price = price
             if balance == 0 or price == 0:

--- a/tqqq_bot_v5/tests/test_engine.py
+++ b/tqqq_bot_v5/tests/test_engine.py
@@ -56,8 +56,12 @@ async def test_engine_places_sell_and_buy_limits(mock_broker, mock_sheet, config
     # Row 8 is NOT has_y and 8 > 7 -> should place BUY.
 
     mock_broker.get_positions.return_value = {"TQQQ": 10} # Matches Row 7 shares
+    mock_broker.get_wallet_balance.return_value = 50000.0
 
     await engine._tick()
+
+    # Should have updated cash balance
+    mock_sheet.write_cash_value.assert_called_with(50000.0)
 
     # Should have called place_limit_order twice
     assert mock_broker.place_limit_order.call_count == 2


### PR DESCRIPTION
This PR restores the V4 dashboard behavior by ensuring the broker-first cash balance is displayed in cell C2 of the 'TQQQ_Tracker' sheet.

Key changes:
- In `GridEngine._tick`, after retrieving the wallet balance from the broker, it is now written to cell C2 via `SheetInterface.write_cash_value`.
- The value is passed as a float to ensure it is stored as a numeric cell in Google Sheets, allowing users to format it as currency.
- Verified that `SheetInterface` already had the necessary `write_cash_value` method and appropriate guards for cell C2.
- Updated `test_engine_places_sell_and_buy_limits` to assert that the cash value is updated correctly.
- All 35 tests passed successfully.

Fixes #64

---
*PR created automatically by Jules for task [4483928714981278632](https://jules.google.com/task/4483928714981278632) started by @Wakeboardsam*