### PR TITLE
PR 4 — Fix anchor acquisition logic

### DIFF
--- a/tqqq_bot_v5/engine/engine.py
+++ b/tqqq_bot_v5/engine/engine.py
@@ -212,10 +212,24 @@ class GridEngine:
                 elif row.row_index > distal_y:
                     # Expect active BUY order
                     if not self.order_manager.has_open_buy(row.row_index):
-                        logger.info(f"Placing missing BUY for empty row {row.row_index}")
+                        buy_price = row.buy_price
+
+                        if row.row_index == 7 and distal_y == 0:
+                            # Anchor acquisition!
+                            logger.info("Anchor acquisition condition met for row 7")
+                            bid, ask = await self.broker.get_bid_ask(TICKER)
+                            if self.spread_guard.is_too_wide(bid, ask):
+                                continue
+
+                            await self.sheet.write_anchor_ask(ask)
+                            buy_price = ask + self.config.anchor_buy_offset
+                            logger.info(f"Placing anchor BUY for row 7 at {buy_price} (ask: {ask}, offset: {self.config.anchor_buy_offset})")
+                        else:
+                            logger.info(f"Placing missing BUY for empty row {row.row_index}")
+
                         result = await self.broker.place_limit_order(
                             ticker=TICKER, action='BUY', qty=row.shares,
-                            limit_price=row.buy_price, on_fill=self._on_fill
+                            limit_price=buy_price, on_fill=self._on_fill
                         )
                         if result.status == 'submitted':
                             self.order_manager.track(row.row_index, result, 'BUY')

--- a/tqqq_bot_v5/tests/test_engine.py
+++ b/tqqq_bot_v5/tests/test_engine.py
@@ -136,3 +136,70 @@ async def test_heartbeat_periodic(mock_broker, mock_sheet, config):
         task.cancel()
 
     assert mock_sheet.write_heartbeat.call_count >= 1
+
+@pytest.mark.asyncio
+async def test_anchor_acquisition(mock_broker, mock_sheet, config):
+    # distal_y == 0 condition
+    grid_state = GridState(
+        rows={
+            7: GridRow(row_index=7, status="IDLE", has_y=False, sell_price=105.0, buy_price=100.0, shares=10),
+            8: GridRow(row_index=8, status="IDLE", has_y=False, sell_price=110.0, buy_price=105.0, shares=10)
+        }
+    )
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.get_positions.return_value = {"TQQQ": 0}
+    mock_broker.get_wallet_balance.return_value = 50000.0
+    mock_broker.get_bid_ask.return_value = (99.9, 100.0)
+    config.anchor_buy_offset = 0.05
+
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    await engine._tick()
+
+    # Should write anchor ask to G7
+    mock_sheet.write_anchor_ask.assert_called_with(100.0)
+
+    # Should place buy order at ask + offset (100.0 + 0.05 = 100.05)
+    mock_broker.place_limit_order.assert_any_call(
+        ticker="TQQQ", action="BUY", qty=10, limit_price=100.05, on_fill=engine._on_fill
+    )
+
+@pytest.mark.asyncio
+async def test_no_anchor_write_if_owned(mock_broker, mock_sheet, config):
+    # distal_y > 0 condition
+    grid_state = GridState(
+        rows={
+            7: GridRow(row_index=7, status="OWNED", has_y=True, sell_price=105.0, buy_price=100.0, shares=10),
+            8: GridRow(row_index=8, status="IDLE", has_y=False, sell_price=110.0, buy_price=105.0, shares=10)
+        }
+    )
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.get_positions.return_value = {"TQQQ": 10}
+    mock_broker.get_wallet_balance.return_value = 50000.0
+
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    await engine._tick()
+
+    # Should NOT write anchor ask to G7
+    mock_sheet.write_anchor_ask.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_no_anchor_write_if_already_working(mock_broker, mock_sheet, config):
+    # Row 7 already has a WORKING_BUY in status, even if distal_y is 0
+    grid_state = GridState(
+        rows={
+            7: GridRow(row_index=7, status="WORKING_BUY:ORD-1", has_y=False, sell_price=105.0, buy_price=100.0, shares=10),
+            8: GridRow(row_index=8, status="IDLE", has_y=False, sell_price=110.0, buy_price=105.0, shares=10)
+        }
+    )
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.get_positions.return_value = {"TQQQ": 0}
+    mock_broker.get_wallet_balance.return_value = 50000.0
+    mock_broker.get_open_orders.return_value = [{'order_id': 'ORD-1', 'limit_price': 100.0, 'qty': 10, 'action': 'BUY'}]
+
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    await engine._tick()
+
+    # Should NOT write anchor ask to G7
+    mock_sheet.write_anchor_ask.assert_not_called()
+    # Should NOT place a new order
+    assert mock_broker.place_limit_order.call_count == 0


### PR DESCRIPTION
This PR fixes the anchor acquisition logic in the TQQQ trading bot. 

Key changes:
- In `GridEngine`, row 7 is now treated as the anchor level (level 0).
- When `distal_y` is 0 (no owned rows) and the bot needs to place a buy order for row 7, it performs an "anchor acquisition".
- During anchor acquisition:
    - The current `bid` and `ask` prices are fetched.
    - The `SpreadGuard` verifies the spread is within limits.
    - The `ask` price is written to `TQQQ_Tracker!G7`.
    - The buy order limit price is calculated as `ask + anchor_buy_offset`.
- G7 is never written during other operations like health checks or when other rows are owned.
- New test cases were added to `tqqq_bot_v5/tests/test_engine.py` to validate these requirements and ensure that G7 is not updated incorrectly.

Fixes #66

---
*PR created automatically by Jules for task [5674018470777915527](https://jules.google.com/task/5674018470777915527) started by @Wakeboardsam*