### PR TITLE
Verify status strings and order lifecycle writes

### DIFF
--- a/tqqq_bot_v5/engine/engine.py
+++ b/tqqq_bot_v5/engine/engine.py
@@ -213,7 +213,6 @@ class GridEngine:
                         if result.status == 'submitted':
                             self.order_manager.track(row.row_index, result, 'SELL')
                             new_status = f"WORKING_SELL:{result.order_id}"
-                            if owned_id: new_status += f"|OWNED:{owned_id}"
                             await self.sheet.update_row_status(row.row_index, new_status)
                 elif row.row_index > distal_y:
                     if mismatch_active:
@@ -256,7 +255,7 @@ class GridEngine:
 
                 # Update status
                 if row.has_y:
-                    new_status = f"OWNED:{owned_id}" if owned_id else "OWNED"
+                    new_status = f"OWNED:{owned_id if owned_id else 0}"
                     if row.status != new_status:
                         await self.sheet.update_row_status(row.row_index, new_status)
                 else:

--- a/tqqq_bot_v5/tests/test_engine.py
+++ b/tqqq_bot_v5/tests/test_engine.py
@@ -68,8 +68,8 @@ async def test_engine_places_sell_and_buy_limits(mock_broker, mock_sheet, config
 
     # Check SELL for row 7
     assert engine.order_manager.has_open_sell(7)
-    # Status should preserve OLD-ID: WORKING_SELL:ORD-123|OWNED:OLD-ID
-    mock_sheet.update_row_status.assert_any_call(7, "WORKING_SELL:ORD-123|OWNED:OLD-ID")
+    # Status should NOT preserve OLD-ID per strict requirements in PR 6
+    mock_sheet.update_row_status.assert_any_call(7, "WORKING_SELL:ORD-123")
 
     # Check BUY for row 8
     assert engine.order_manager.has_open_buy(8)

--- a/tqqq_bot_v5/tests/test_status_strings.py
+++ b/tqqq_bot_v5/tests/test_status_strings.py
@@ -1,0 +1,177 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime
+
+from engine.engine import GridEngine
+from engine.grid_state import GridState, GridRow
+from brokers.base import OrderResult
+from config.schema import AppConfig
+
+@pytest.fixture
+def mock_broker():
+    broker = AsyncMock()
+    broker.connect = AsyncMock(return_value=True)
+    broker.disconnect = AsyncMock()
+    broker.ensure_connected = AsyncMock()
+    broker.get_bid_ask = AsyncMock(return_value=(99.95, 100.05))
+    broker.place_limit_order = AsyncMock(return_value=OrderResult(order_id="ORD-123", status="submitted"))
+    broker.get_open_orders = AsyncMock(return_value=[])
+    broker.get_positions = AsyncMock(return_value={"TQQQ": 0})
+    broker.subscribe_to_fill = MagicMock()
+    broker.cancel_order = AsyncMock(return_value=True)
+    return broker
+
+@pytest.fixture
+def mock_sheet():
+    sheet = AsyncMock()
+    sheet.log_fill = AsyncMock(return_value=True)
+    sheet.log_error = AsyncMock(return_value=True)
+    sheet.log_health = AsyncMock(return_value=True)
+    sheet.update_row_status = AsyncMock(return_value=True)
+    sheet.write_cash_value = AsyncMock(return_value=True)
+    return sheet
+
+@pytest.fixture
+def config():
+    return AppConfig(
+        google_sheet_id="test_sheet",
+        google_credentials_json='{"test": "json"}',
+        poll_interval_seconds=1,
+        max_spread_pct=0.5
+    )
+
+@pytest.mark.asyncio
+async def test_transition_idle_to_working_buy(mock_broker, mock_sheet, config):
+    grid_state = GridState(rows={
+        10: GridRow(row_index=10, status="IDLE", has_y=False, sell_price=110.0, buy_price=105.0, shares=10)
+    })
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.place_limit_order.return_value = OrderResult(order_id="BUY-123", status="submitted")
+
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    # Mock distal_y = 7, so row 10 is in window [7, 10]
+    with patch.object(GridState, 'distal_y_row', 7):
+        await engine._tick()
+
+    mock_sheet.update_row_status.assert_called_with(10, "WORKING_BUY:BUY-123")
+
+@pytest.mark.asyncio
+async def test_transition_working_buy_to_owned(mock_broker, mock_sheet, config):
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    # Manually track an order
+    engine.order_manager.track(10, OrderResult(order_id="BUY-123", status="submitted"), 'BUY')
+
+    # Simulate fill
+    fill_details = {'order_id': 'BUY-123', 'price': 105.0, 'qty': 10}
+    engine._on_fill(fill_details)
+
+    # Wait for the async task in _on_fill
+    await asyncio.sleep(0.1)
+
+    mock_sheet.update_row_status.assert_called_with(10, "OWNED:BUY-123")
+
+@pytest.mark.asyncio
+async def test_transition_owned_to_working_sell(mock_broker, mock_sheet, config):
+    grid_state = GridState(rows={
+        10: GridRow(row_index=10, status="OWNED:BUY-123", has_y=True, sell_price=110.0, buy_price=105.0, shares=10)
+    })
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.get_positions.return_value = {"TQQQ": 10}
+    mock_broker.place_limit_order.return_value = OrderResult(order_id="SELL-456", status="submitted")
+
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    # Row 10 is in window
+    with patch.object(GridState, 'distal_y_row', 10):
+        await engine._tick()
+
+    mock_sheet.update_row_status.assert_called_with(10, "WORKING_SELL:SELL-456")
+
+@pytest.mark.asyncio
+async def test_transition_working_sell_to_idle(mock_broker, mock_sheet, config):
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    # Manually track an order
+    engine.order_manager.track(10, OrderResult(order_id="SELL-456", status="submitted"), 'SELL')
+
+    # Simulate fill
+    fill_details = {'order_id': 'SELL-456', 'price': 110.0, 'qty': 10}
+    engine._on_fill(fill_details)
+
+    # Wait for the async task in _on_fill
+    await asyncio.sleep(0.1)
+
+    mock_sheet.update_row_status.assert_called_with(10, "IDLE")
+
+@pytest.mark.asyncio
+async def test_cancel_outside_window_working_buy(mock_broker, mock_sheet, config):
+    grid_state = GridState(rows={
+        15: GridRow(row_index=15, status="WORKING_BUY:BUY-123", has_y=False, sell_price=150.0, buy_price=145.0, shares=10)
+    })
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.get_open_orders.return_value = [{'order_id': 'BUY-123', 'action': 'BUY'}]
+
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    # distal_y = 7, window [7, 10]. Row 15 is outside.
+    with patch.object(GridState, 'distal_y_row', 7):
+        await engine._tick()
+
+    # Should cancel and update to IDLE
+    mock_broker.cancel_order.assert_called_with("BUY-123")
+    mock_sheet.update_row_status.assert_called_with(15, "IDLE")
+
+@pytest.mark.asyncio
+async def test_cancel_outside_window_working_sell(mock_broker, mock_sheet, config):
+    grid_state = GridState(rows={
+        7: GridRow(row_index=7, status="WORKING_SELL:SELL-456|OWNED:BUY-123", has_y=True, sell_price=105.0, buy_price=100.0, shares=10)
+    })
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.get_positions.return_value = {"TQQQ": 10}
+    mock_broker.get_open_orders.return_value = [{'order_id': 'SELL-456', 'action': 'SELL'}]
+
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    # distal_y = 15, window [12, 18]. Row 7 is outside.
+    with patch.object(GridState, 'distal_y_row', 15):
+        await engine._tick()
+
+    # Should cancel and update to OWNED:BUY-123
+    mock_broker.cancel_order.assert_called_with("SELL-456")
+    mock_sheet.update_row_status.assert_called_with(7, "OWNED:BUY-123")
+
+@pytest.mark.asyncio
+async def test_owned_fallback_enforcement(mock_broker, mock_sheet, config):
+    # Testing the case where we have WORKING_SELL but NO OWNED info, and it goes outside window
+    grid_state = GridState(rows={
+        7: GridRow(row_index=7, status="WORKING_SELL:SELL-456", has_y=True, sell_price=105.0, buy_price=100.0, shares=10)
+    })
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.get_positions.return_value = {"TQQQ": 10}
+    mock_broker.get_open_orders.return_value = [{'order_id': 'SELL-456', 'action': 'SELL'}]
+
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    # distal_y = 15, window [12, 18]. Row 7 is outside.
+    with patch.object(GridState, 'distal_y_row', 15):
+        await engine._tick()
+
+    # Current behavior might be "OWNED", but we want to enforce "OWNED:0" or similar if ID is missing.
+    # The requirement says "Confirm the bot only writes these status patterns to C7:C100: WORKING_BUY:12345, WORKING_SELL:12345, OWNED:12345, IDLE"
+    # So "OWNED" without ID might be forbidden if we are being strict.
+    mock_sheet.update_row_status.assert_called_with(7, "OWNED:0")
+
+@pytest.mark.asyncio
+async def test_retrack_parsing(mock_broker, mock_sheet, config):
+    # Verify that we correctly parse the complex status string and re-track orders
+    grid_state = GridState(rows={
+        7: GridRow(row_index=7, status="WORKING_SELL:SELL-123|OWNED:BUY-789", has_y=True, sell_price=105.0, buy_price=100.0, shares=10)
+    })
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.get_positions.return_value = {"TQQQ": 10}
+    mock_broker.get_open_orders.return_value = [{'order_id': 'SELL-123', 'action': 'SELL'}]
+
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    with patch.object(GridState, 'distal_y_row', 7):
+        await engine._tick()
+
+    assert engine.order_manager.is_tracked("SELL-123")
+    assert engine.order_manager.has_open_sell(7)
+    # It should NOT update status since it's already correct
+    mock_sheet.update_row_status.assert_not_called()


### PR DESCRIPTION
This PR standardizes the status strings written to the Google Sheet (Column C) to ensure they are compatible with spreadsheet formulas. The bot now strictly writes only four patterns: `WORKING_BUY:ID`, `WORKING_SELL:ID`, `OWNED:ID`, and `IDLE`. A new test suite has been added to verify these transitions across the entire order lifecycle (placement, fill, cancel, and re-tracking).

Fixes #70

---
*PR created automatically by Jules for task [5441547960248921429](https://jules.google.com/task/5441547960248921429) started by @Wakeboardsam*