### PR TITLE
PR 8 — IBKR cash field selection

### DIFF
--- a/tqqq_bot_v5/brokers/ibkr/adapter.py
+++ b/tqqq_bot_v5/brokers/ibkr/adapter.py
@@ -17,6 +17,7 @@ class IBKRAdapter(BrokerBase):
         self.paper = paper
         self.ib = IB()
         self._on_fill_callbacks: dict[str, Callable] = {}
+        self._selected_cash_tag: Optional[str] = None
 
         # Subscribe to order status events
         self.ib.orderStatusEvent += self._on_order_status
@@ -107,20 +108,44 @@ class IBKRAdapter(BrokerBase):
 
     async def get_wallet_balance(self) -> float:
         """
-        Returns the USD TotalCashValue or TotalCashBalance from the account.
+        Returns the USD balance from the selected conservative account tag.
         """
         try:
             account_values = self.ib.accountValues()
-            logger.info(f"Raw balance response: {account_values}")
-            balance = next((float(v.value) for v in account_values if v.tag == 'TotalCashValue' and v.currency == 'USD'), 0.0)
-
-            if balance == 0.0 and not account_values:
+            if not account_values:
                 logger.error("API call returned empty — possible Gateway auth or subscription issue")
+                return 0.0
 
-            return balance
+            # Filter for USD only
+            usd_values = [v for v in account_values if v.currency == 'USD']
+
+            if not self._selected_cash_tag:
+                # 1. Search for "Settled" (case-insensitive)
+                settled_tag = next((v.tag for v in usd_values if "settled" in v.tag.lower()), None)
+                if settled_tag:
+                    self._selected_cash_tag = settled_tag
+                else:
+                    # 2. Fallback to confirmed tags
+                    for fallback in ["TotalCashValue", "TotalCashBalance"]:
+                        if any(v.tag == fallback for v in usd_values):
+                            self._selected_cash_tag = fallback
+                            break
+
+                if self._selected_cash_tag:
+                    logger.info(f"Selected IBKR cash field: {self._selected_cash_tag}")
+                else:
+                    available_tags = [v.tag for v in usd_values]
+                    logger.warning(f"No preferred conservative cash tags found. Available USD tags: {available_tags}")
+                    return 0.0
+
+            # Retrieve value for the selected tag
+            balance_entry = next((v for v in usd_values if v.tag == self._selected_cash_tag), None)
+            if balance_entry:
+                return float(balance_entry.value)
+
+            return 0.0
         except Exception as e:
             logger.error(f"Error fetching balance: {e}")
-            logger.error("API call returned empty — possible Gateway auth or subscription issue")
             return 0.0
 
     async def place_limit_order(

--- a/tqqq_bot_v5/tests/test_ibkr_adapter.py
+++ b/tqqq_bot_v5/tests/test_ibkr_adapter.py
@@ -165,30 +165,67 @@ async def test_get_price_fallbacks(mock_ib):
     assert price == 52.0
 
 @pytest.mark.asyncio
-async def test_get_wallet_balance(mock_ib):
+async def test_get_wallet_balance_selection_settled(mock_ib):
     adapter = IBKRAdapter(host='localhost', port=7497, client_id=1, paper=True)
     adapter.ib = mock_ib
 
-    # Mock accountValues
-    val1 = MagicMock()
-    val1.tag = 'NetLiquidation'
-    val1.value = '1000.0'
-    val1.currency = 'USD'
+    # Mock accountValues: SettledCash should win
+    v1 = MagicMock(tag='NetLiquidation', value='1000.0', currency='USD')
+    v2 = MagicMock(tag='TotalCashValue', value='500.0', currency='USD')
+    v3 = MagicMock(tag='SettledCash', value='400.0', currency='USD')
+    v4 = MagicMock(tag='SettledCash', value='300.0', currency='EUR')
 
-    val2 = MagicMock()
-    val2.tag = 'TotalCashValue'
-    val2.value = '500.0'
-    val2.currency = 'USD'
+    mock_ib.accountValues.return_value = [v1, v2, v3, v4]
 
-    val3 = MagicMock()
-    val3.tag = 'TotalCashBalance'
-    val3.value = '100.0'
-    val3.currency = 'EUR'
+    balance = await adapter.get_wallet_balance()
+    assert balance == 400.0
+    assert adapter._selected_cash_tag == 'SettledCash'
 
-    mock_ib.accountValues = MagicMock(return_value=[val1, val2, val3])
+@pytest.mark.asyncio
+async def test_get_wallet_balance_selection_fallback_total(mock_ib):
+    adapter = IBKRAdapter(host='localhost', port=7497, client_id=1, paper=True)
+    adapter.ib = mock_ib
+
+    # No settled tag, TotalCashValue should win
+    v1 = MagicMock(tag='NetLiquidation', value='1000.0', currency='USD')
+    v2 = MagicMock(tag='TotalCashValue', value='500.0', currency='USD')
+    v3 = MagicMock(tag='TotalCashBalance', value='450.0', currency='USD')
+
+    mock_ib.accountValues.return_value = [v1, v2, v3]
 
     balance = await adapter.get_wallet_balance()
     assert balance == 500.0
+    assert adapter._selected_cash_tag == 'TotalCashValue'
+
+@pytest.mark.asyncio
+async def test_get_wallet_balance_selection_fallback_balance(mock_ib):
+    adapter = IBKRAdapter(host='localhost', port=7497, client_id=1, paper=True)
+    adapter.ib = mock_ib
+
+    # Only TotalCashBalance available
+    v1 = MagicMock(tag='NetLiquidation', value='1000.0', currency='USD')
+    v2 = MagicMock(tag='TotalCashBalance', value='450.0', currency='USD')
+
+    mock_ib.accountValues.return_value = [v1, v2]
+
+    balance = await adapter.get_wallet_balance()
+    assert balance == 450.0
+    assert adapter._selected_cash_tag == 'TotalCashBalance'
+
+@pytest.mark.asyncio
+async def test_get_wallet_balance_no_match(mock_ib):
+    adapter = IBKRAdapter(host='localhost', port=7497, client_id=1, paper=True)
+    adapter.ib = mock_ib
+
+    # No preferred tags
+    v1 = MagicMock(tag='NetLiquidation', value='1000.0', currency='USD')
+    v2 = MagicMock(tag='BuyingPower', value='2000.0', currency='USD')
+
+    mock_ib.accountValues.return_value = [v1, v2]
+
+    balance = await adapter.get_wallet_balance()
+    assert balance == 0.0
+    assert adapter._selected_cash_tag is None
 
 @pytest.mark.asyncio
 async def test_place_limit_order_outside_rth(mock_ib):


### PR DESCRIPTION
This PR implements a more conservative cash field selection mechanism in the IBKR adapter to ensure the bot uses settled cash rather than margin buying power.

The adapter now dynamically inspects available account value tags in USD and selects the most appropriate one based on a prioritized hierarchy:
1. Any tag containing "settled" (e.g., `SettledCash`).
2. `TotalCashValue`.
3. `TotalCashBalance`.

This selected tag is used for both internal strategy logic and mirroring to the Google Sheet (C2). The selection is logged upon first use to provide visibility into the bot's behavior. If no matching tags are found, the bot logs a warning and defaults to a safe 0.0 balance.

Comprehensive unit tests have been added to verify the prioritization and fallback logic across various scenarios.

Fixes #74

---
*PR created automatically by Jules for task [1971043716883107825](https://jules.google.com/task/1971043716883107825) started by @Wakeboardsam*