### PR TITLE
PR 10 — Sync Home Assistant add-on config UI with runtime config

### DIFF
--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -13,9 +13,11 @@ options:
   ibkr_host: "127.0.0.1"
   ibkr_port: 7497
   ibkr_client_id: 1
-  poll_interval_seconds: 30
+  poll_interval_seconds: 60
   heartbeat_interval_seconds: 60
   health_log_interval_seconds: 300
+  anchor_buy_offset: 0.0
+  share_mismatch_mode: "halt"
   max_spread_pct: 0.5
   google_sheet_id: ""
   google_credentials_json: ""
@@ -30,6 +32,8 @@ schema:
   poll_interval_seconds: "int"
   heartbeat_interval_seconds: "int"
   health_log_interval_seconds: "int"
+  anchor_buy_offset: "float"
+  share_mismatch_mode: "list(halt|warn)"
   max_spread_pct: "float"
   google_sheet_id: "str"
   google_credentials_json: "str"


### PR DESCRIPTION
This PR synchronizes the Home Assistant add-on configuration UI with the actual runtime options used by the bot. It exposes `anchor_buy_offset` and `share_mismatch_mode` to the user and ensures that default values like `poll_interval_seconds` are consistent across the metadata and the code.

Fixes #78

---
*PR created automatically by Jules for task [535978757884581023](https://jules.google.com/task/535978757884581023) started by @Wakeboardsam*