### PR TITLE
Explicit IBKR paper/live mode and port handling

### DIFF
--- a/tqqq_bot_v5/config/loader.py
+++ b/tqqq_bot_v5/config/loader.py
@@ -4,6 +4,28 @@ from pydantic import ValidationError
 from config.schema import AppConfig
 
 
+def validate_ibkr_settings(config: AppConfig) -> list[str]:
+    """
+    Validates that paper_trading and ibkr_port are consistent with IBKR defaults.
+    Returns a list of warning messages.
+    """
+    warnings = []
+    if config.active_broker == "ibkr":
+        if config.paper_trading:
+            if config.ibkr_port != 7497:
+                warnings.append(
+                    f"Inconsistency detected: paper_trading=True but ibkr_port={config.ibkr_port}. "
+                    "IBKR default paper port is 7497."
+                )
+        else:
+            if config.ibkr_port != 7496:
+                warnings.append(
+                    f"Inconsistency detected: paper_trading=False (LIVE) but ibkr_port={config.ibkr_port}. "
+                    "IBKR default live port is 7496."
+                )
+    return warnings
+
+
 def load_config(path: str = "/data/options.json") -> AppConfig:
     try:
         with open(path, "r") as f:

--- a/tqqq_bot_v5/main.py
+++ b/tqqq_bot_v5/main.py
@@ -1,7 +1,7 @@
 import sys
 import asyncio
 import logging
-from config.loader import load_config
+from config.loader import load_config, validate_ibkr_settings
 from brokers.ibkr.adapter import IBKRAdapter
 from brokers.schwab.adapter import SchwabAdapter
 from engine.engine import GridEngine
@@ -21,6 +21,11 @@ async def main():
     except Exception as e:
         print(f"Error loading config: {e}", file=sys.stderr)
         sys.exit(1)
+
+    # Perform IBKR port/mode validation
+    ibkr_warnings = validate_ibkr_settings(config)
+    for warning in ibkr_warnings:
+        logger.warning(warning)
 
     if config.active_broker == "ibkr":
         broker = IBKRAdapter(

--- a/tqqq_bot_v5/run.sh
+++ b/tqqq_bot_v5/run.sh
@@ -2,6 +2,7 @@
 echo "Parsing Home Assistant options..."
 IBKR_USER=$(jq -r '.ibkr_username // empty' /data/options.json)
 IBKR_PASS=$(jq -r '.ibkr_password // empty' /data/options.json)
+export IBKR_PORT=$(jq -r '.ibkr_port // 7497' /data/options.json)
 PAPER_FLAG=$(jq -r '.paper_trading' /data/options.json)
 TRADING_MODE="paper"
 if [ "$PAPER_FLAG" = "false" ]; then
@@ -15,7 +16,7 @@ IbPassword=${IBKR_PASS}
 TradingMode=${TRADING_MODE}
 IbDir=/root/Jts
 ReadOnlyApi=no
-OverrideTwsApiPort=7497
+OverrideTwsApiPort=${IBKR_PORT}
 AcceptIncomingConnectionAction=accept
 AcceptNonBrokerageAccountWarning=yes
 EOF

--- a/tqqq_bot_v5/supervisord.conf
+++ b/tqqq_bot_v5/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/dev/null
 logfile_maxbytes=0
 
 [program:botpy]
-command=bash -c "python gateway/wait_for_gateway.py --port 7497 --timeout 300 && python main.py"
+command=bash -c "python gateway/wait_for_gateway.py --port %(ENV_IBKR_PORT)s --timeout 300 && python main.py"
 autostart=true
 autorestart=true
 startsecs=30

--- a/tqqq_bot_v5/tests/test_config.py
+++ b/tqqq_bot_v5/tests/test_config.py
@@ -2,7 +2,7 @@ import pytest
 import json
 import os
 from pydantic import ValidationError
-from config.loader import load_config
+from config.loader import load_config, validate_ibkr_settings
 from config.schema import AppConfig
 
 
@@ -41,3 +41,61 @@ def test_missing_google_sheet_id(tmp_path):
 
     assert e.type == SystemExit
     assert e.value.code == 1
+
+
+def test_validate_ibkr_settings_paper_correct():
+    config = AppConfig(
+        google_sheet_id="id",
+        google_credentials_json="{}",
+        paper_trading=True,
+        ibkr_port=7497
+    )
+    warnings = validate_ibkr_settings(config)
+    assert len(warnings) == 0
+
+
+def test_validate_ibkr_settings_live_correct():
+    config = AppConfig(
+        google_sheet_id="id",
+        google_credentials_json="{}",
+        paper_trading=False,
+        ibkr_port=7496
+    )
+    warnings = validate_ibkr_settings(config)
+    assert len(warnings) == 0
+
+
+def test_validate_ibkr_settings_paper_inconsistent():
+    config = AppConfig(
+        google_sheet_id="id",
+        google_credentials_json="{}",
+        paper_trading=True,
+        ibkr_port=7496
+    )
+    warnings = validate_ibkr_settings(config)
+    assert len(warnings) == 1
+    assert "paper_trading=True but ibkr_port=7496" in warnings[0]
+
+
+def test_validate_ibkr_settings_live_inconsistent():
+    config = AppConfig(
+        google_sheet_id="id",
+        google_credentials_json="{}",
+        paper_trading=False,
+        ibkr_port=7497
+    )
+    warnings = validate_ibkr_settings(config)
+    assert len(warnings) == 1
+    assert "paper_trading=False (LIVE) but ibkr_port=7497" in warnings[0]
+
+
+def test_validate_ibkr_settings_custom_port():
+    config = AppConfig(
+        google_sheet_id="id",
+        google_credentials_json="{}",
+        paper_trading=True,
+        ibkr_port=4001
+    )
+    warnings = validate_ibkr_settings(config)
+    assert len(warnings) == 1
+    assert "paper_trading=True but ibkr_port=4001" in warnings[0]


### PR DESCRIPTION
This PR makes the IBKR trading mode and port handling explicit by validating that the configured port matches the expected default for the selected trading mode (paper vs live). It provides startup warnings for inconsistencies without silently overriding user settings. Additionally, it ensures that the user-specified port is consistently used by the IB Gateway and the startup polling scripts.

Fixes #80

---
*PR created automatically by Jules for task [16653948538449614102](https://jules.google.com/task/16653948538449614102) started by @Wakeboardsam*