### PR TITLE
fix: IBKRAdapter bid/ask fallback to last/close prices

### DIFF
--- a/tqqq_bot_v5/brokers/ibkr/adapter.py
+++ b/tqqq_bot_v5/brokers/ibkr/adapter.py
@@ -80,8 +80,6 @@ class IBKRAdapter(BrokerBase):
                 return ticker_data.last
             if ticker_data.close > 0:
                 return ticker_data.close
-            if ticker_data.delayedLast > 0:
-                return ticker_data.delayedLast
 
             logger.error("API call returned empty — possible Gateway auth or subscription issue")
             raise RuntimeError(f"Could not get price for {ticker}")
@@ -105,7 +103,23 @@ class IBKRAdapter(BrokerBase):
                     return ticker_data.bid, ticker_data.ask
                 await asyncio.sleep(0.1)
 
+            # Fallback to last/close prices if bid/ask is unavailable
+            fallback_price = None
+            if ticker_data.last > 0:
+                fallback_price = ticker_data.last
+            elif ticker_data.close > 0:
+                fallback_price = ticker_data.close
+
+            if fallback_price is not None:
+                logger.warning(f"Bid/Ask unavailable for {ticker}, falling back to last/close price: {fallback_price}")
+                return fallback_price, fallback_price
+
+            logger.error("API call returned empty — possible Gateway auth or subscription issue")
             raise RuntimeError(f"Could not get bid/ask for {ticker}")
+        except Exception as e:
+            if not isinstance(e, RuntimeError):
+                logger.error(f"Error fetching bid/ask: {e}")
+            raise
         finally:
             self.ib.cancelMktData(contract)
 

--- a/tqqq_bot_v5/tests/test_ibkr_adapter.py
+++ b/tqqq_bot_v5/tests/test_ibkr_adapter.py
@@ -161,13 +161,6 @@ async def test_get_price_fallbacks(mock_ib):
     price = await adapter.get_price('TQQQ')
     assert price == 51.0
 
-    # Test delayedLast fallback
-    mock_ticker.last = 0.0
-    mock_ticker.close = 0.0
-    mock_ticker.delayedLast = 52.0
-
-    price = await adapter.get_price('TQQQ')
-    assert price == 52.0
 
 @pytest.mark.asyncio
 async def test_get_wallet_balance_selection_settled(mock_ib):
@@ -330,3 +323,21 @@ def test_build_bracket_order_contract_routing(mock_ib):
             assert c.symbol == 'TQQQ'
             assert c.exchange == 'OVERNIGHT'
             assert c.primaryExchange == 'NASDAQ'
+
+@pytest.mark.asyncio
+async def test_get_bid_ask_fallback(mock_ib):
+    adapter = IBKRAdapter(host='localhost', port=7497, client_id=1, paper=True)
+    adapter.ib = mock_ib
+
+    mock_ticker = MagicMock()
+    mock_ticker.bid = 0.0
+    mock_ticker.ask = 0.0
+    mock_ticker.last = 50.5
+    mock_ticker.close = 50.0
+
+    mock_ib.reqMktData.return_value = mock_ticker
+
+    with patch('brokers.ibkr.order_builder.get_dynamic_exchange', return_value='OVERNIGHT'):
+        bid, ask = await adapter.get_bid_ask('TQQQ')
+        assert bid == 50.5
+        assert ask == 50.5


### PR DESCRIPTION
Fixes an issue where the bot fails to acquire the anchor buy (G7) overnight or when delayed data has no explicit `bid`/`ask` available. The bot will now correctly fall back to the `last` or `close` price, simulating a 0-spread quote to allow the anchor order to proceed.

Also removed references to `delayedLast` from `get_price` to avoid an `AttributeError`, as `ib_insync` maps delayed quotes directly to the `last` property.

---
*PR created automatically by Jules for task [8708822218810157711](https://jules.google.com/task/8708822218810157711) started by @Wakeboardsam*