### PR TITLE
Wait for confirmed live price on startup

### DIFF
--- a/tqqq_bot_v5/engine/engine.py
+++ b/tqqq_bot_v5/engine/engine.py
@@ -47,6 +47,9 @@ class GridEngine:
 
         await self.broker.connect()
 
+        # Wait for a valid price before starting anything else
+        await self._wait_for_initial_price()
+
         # Start periodic tasks
         health_task = asyncio.create_task(self._log_health_periodic())
         heartbeat_task = asyncio.create_task(self._heartbeat_periodic())
@@ -85,6 +88,37 @@ class GridEngine:
     def _handle_shutdown_signal(self):
         logger.info("Shutdown signal received.")
         self._shutdown_event.set()
+
+    async def _wait_for_initial_price(self):
+        """
+        Explicitly poll for price and wait until a non-zero value is confirmed.
+        Retry every 10 seconds for up to 240 seconds.
+        """
+        logger.info(f"Waiting for initial confirmed price for {TICKER}...")
+        start_time = asyncio.get_event_loop().time()
+        timeout = 240
+        interval = 10
+
+        while not self._shutdown_event.is_set():
+            try:
+                price = await self.broker.get_price(TICKER)
+                if price > 0:
+                    self.last_price = price
+                    logger.info(f"Initial price confirmed: {price}")
+                    return
+            except Exception as e:
+                logger.warning(f"Error fetching initial price: {e}")
+
+            elapsed = asyncio.get_event_loop().time() - start_time
+            if elapsed >= timeout:
+                logger.error(f"Timed out waiting for initial price after {timeout}s")
+                break
+
+            logger.info(f"Price not yet available, retrying in {interval}s... (Elapsed: {int(elapsed)}s)")
+            try:
+                await asyncio.wait_for(self._shutdown_event.wait(), timeout=interval)
+            except asyncio.TimeoutError:
+                pass
 
     async def _cancel_all_orders(self):
         tracked_ids = self.order_manager.get_tracked_order_ids()

--- a/tqqq_bot_v5/tests/test_startup_price_wait.py
+++ b/tqqq_bot_v5/tests/test_startup_price_wait.py
@@ -1,0 +1,56 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from engine.engine import GridEngine
+from config.schema import AppConfig
+
+@pytest.fixture
+def mock_broker():
+    broker = AsyncMock()
+    broker.connect = AsyncMock(return_value=True)
+    broker.get_price = AsyncMock()
+    return broker
+
+@pytest.fixture
+def mock_sheet():
+    sheet = AsyncMock()
+    return sheet
+
+@pytest.fixture
+def config():
+    return AppConfig(
+        google_sheet_id="test_sheet",
+        google_credentials_json='{"test": "json"}',
+        poll_interval_seconds=1,
+        max_spread_pct=0.5
+    )
+
+@pytest.mark.asyncio
+async def test_wait_for_initial_price_retries(mock_broker, mock_sheet, config):
+    # Mock get_price to return 0 twice, then 100.0
+    mock_broker.get_price.side_effect = [0.0, 0.0, 100.0]
+    engine = GridEngine(mock_broker, mock_sheet, config)
+
+    # Patch wait_for to simulate timeout for the interval sleep
+    with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+        await engine._wait_for_initial_price()
+
+    assert mock_broker.get_price.call_count == 3
+    assert engine.last_price == 100.0
+
+@pytest.mark.asyncio
+async def test_run_calls_wait_for_initial_price(mock_broker, mock_sheet, config):
+    mock_broker.get_price.return_value = 100.0
+    engine = GridEngine(mock_broker, mock_sheet, config)
+
+    # Mock _wait_for_initial_price to avoid actual wait logic
+    engine._wait_for_initial_price = AsyncMock()
+
+    # Stop engine immediately in first tick
+    mock_sheet.fetch_grid.side_effect = Exception("Stop engine")
+    # Actually just set shutdown event
+    engine._shutdown_event.set()
+
+    await engine.run()
+
+    engine._wait_for_initial_price.assert_called_once()


### PR DESCRIPTION
This change fixes a race condition on startup where the bot might proceed with grid generation and anchor buy logic using a stale or missing price. It introduces an explicit wait for a non-zero price from the broker immediately after connection. The bot will retry every 10 seconds for up to 240 seconds before proceeding (or stopping if the shutdown event is set).

Fixes #93

---
*PR created automatically by Jules for task [12518563554281670847](https://jules.google.com/task/12518563554281670847) started by @Wakeboardsam*