### PR TITLE
Fix Startup Bugs: G7 Anchor Logic and Price Fetch Wait

### DIFF
--- a/tqqq_bot_v5/engine/engine.py
+++ b/tqqq_bot_v5/engine/engine.py
@@ -28,6 +28,7 @@ class GridEngine:
         self._last_reconciliation = datetime.min
         self.last_price = 0.0
         self.last_fill_time: Optional[datetime] = None
+        self.last_broker_shares = 0
         self._shutdown_event = asyncio.Event()
         tz = zoneinfo.ZoneInfo("America/New_York")
         self._last_grid_regeneration = datetime.min.replace(tzinfo=tz)
@@ -49,6 +50,11 @@ class GridEngine:
 
         # Wait for a valid price before starting anything else
         await self._wait_for_initial_price()
+
+        if self._shutdown_event.is_set():
+            logger.critical("Engine shutdown initiated during startup. Aborting run.")
+            await self.broker.disconnect()
+            return
 
         # Start periodic tasks
         health_task = asyncio.create_task(self._log_health_periodic())
@@ -92,12 +98,12 @@ class GridEngine:
     async def _wait_for_initial_price(self):
         """
         Explicitly poll for price and wait until a non-zero value is confirmed.
-        Retry every 10 seconds for up to 240 seconds.
+        Retry every 1 second for up to 30 seconds.
         """
         logger.info(f"Waiting for initial confirmed price for {TICKER}...")
         start_time = asyncio.get_event_loop().time()
-        timeout = 240
-        interval = 10
+        timeout = 30
+        interval = 1
 
         while not self._shutdown_event.is_set():
             try:
@@ -111,7 +117,8 @@ class GridEngine:
 
             elapsed = asyncio.get_event_loop().time() - start_time
             if elapsed >= timeout:
-                logger.error(f"Timed out waiting for initial price after {timeout}s")
+                logger.critical(f"CRITICAL: Timed out waiting for initial price after {timeout}s. Exiting.")
+                self._shutdown_event.set()
                 break
 
             logger.info(f"Price not yet available, retrying in {interval}s... (Elapsed: {int(elapsed)}s)")
@@ -152,6 +159,21 @@ class GridEngine:
                 await asyncio.wait_for(self._shutdown_event.wait(), timeout=self.config.health_log_interval_seconds)
             except asyncio.TimeoutError:
                 pass
+
+    async def _write_fresh_anchor_ask(self):
+        """
+        Fetches the current ask price and writes it to G7.
+        Used to reset the anchor and trigger a sheet recalculation.
+        """
+        try:
+            bid, ask = await self.broker.get_bid_ask(TICKER)
+            if ask > 0:
+                await self.sheet.write_anchor_ask(ask)
+                logger.info(f"Fresh anchor ask {ask} written to G7.")
+            else:
+                logger.warning("Could not write fresh anchor ask: ask price is 0.")
+        except Exception as e:
+            logger.error(f"Failed to write fresh anchor ask: {e}")
 
     async def _heartbeat_periodic(self):
         while not self._shutdown_event.is_set():
@@ -261,6 +283,12 @@ class GridEngine:
         # 2. Circuit Breaker
         positions = await self.broker.get_positions()
         broker_shares = positions.get(TICKER, 0)
+
+        # Bug 1 Fix: Write G7 only after a full sell cycle complete
+        if self.last_broker_shares > 0 and broker_shares == 0:
+            logger.info("Full sell cycle detected (shares went to 0). Updating G7 anchor.")
+            await self._write_fresh_anchor_ask()
+
         sheet_shares = sum(row.shares for row in self.grid_state.rows.values() if row.has_y)
         mismatch_active = False
 
@@ -359,13 +387,13 @@ class GridEngine:
                         if row.row_index == 7 and distal_y == 0:
                             # Anchor acquisition!
                             logger.info("Anchor acquisition condition met for row 7")
+                            # We check spread using a fresh ask but we DO NOT write it to G7 here.
+                            # We use the existing buy_price from the sheet (calculated from current G7).
                             bid, ask = await self.broker.get_bid_ask(TICKER)
                             if self.spread_guard.is_too_wide(bid, ask):
                                 continue
 
-                            await self.sheet.write_anchor_ask(ask)
-                            buy_price = ask + self.config.anchor_buy_offset
-                            logger.info(f"Placing anchor BUY for row 7 at {buy_price} (ask: {ask}, offset: {self.config.anchor_buy_offset})")
+                            logger.info(f"Placing anchor BUY for row 7 at {buy_price} (sheet-derived)")
                         else:
                             logger.info(f"Placing missing BUY for empty row {row.row_index}")
 
@@ -409,6 +437,9 @@ class GridEngine:
                     if row.status != "IDLE":
                         await self.sheet.update_row_status(row.row_index, "IDLE")
 
+        # Update last broker shares at end of tick
+        self.last_broker_shares = broker_shares
+
     def _handle_order_update(self, result: OrderResult):
         order_id = result.order_id
         if result.status == 'filled':
@@ -440,6 +471,14 @@ class GridEngine:
             row_index, action = self.order_manager.mark_cancelled(order_id)
             if row_index:
                 logger.info(f"Order {order_id} for row {row_index} {result.status}. Stopping tracking.")
+
+                # Bug 1 Fix: Write G7 if anchor buy was cancelled with 0 fill
+                if row_index == 7 and action == 'BUY':
+                    filled_qty = result.filled_qty if result.filled_qty is not None else 0
+                    if filled_qty == 0:
+                        logger.info("Anchor BUY cancelled/errored with 0 fill. Updating G7 anchor.")
+                        asyncio.create_task(self._write_fresh_anchor_ask())
+
                 # We do NOT automatically revert status to IDLE/OWNED here
                 # because the next _tick will see the order is missing and decide what to do
                 # (e.g. replace it if it's still in window).

--- a/tqqq_bot_v5/tests/test_engine.py
+++ b/tqqq_bot_v5/tests/test_engine.py
@@ -164,12 +164,12 @@ async def test_anchor_acquisition(mock_broker, mock_sheet, config):
     engine = GridEngine(mock_broker, mock_sheet, config)
     await engine._tick()
 
-    # Should write anchor ask to G7
-    mock_sheet.write_anchor_ask.assert_called_with(100.0)
+    # Bug 1 Fix: Should NOT write anchor ask to G7 on buy placement
+    mock_sheet.write_anchor_ask.assert_not_called()
 
-    # Should place buy order at ask + offset (100.0 + 0.05 = 100.05)
+    # Should place buy order at price from sheet
     mock_broker.place_limit_order.assert_any_call(
-        ticker="TQQQ", action="BUY", qty=10, limit_price=100.05, on_update=engine._handle_order_update, order_id="ORD-123"
+        ticker="TQQQ", action="BUY", qty=10, limit_price=100.0, on_update=engine._handle_order_update, order_id="ORD-123"
     )
 
 @pytest.mark.asyncio
@@ -249,6 +249,52 @@ async def test_engine_boundary_regeneration(mock_broker, mock_sheet, config):
     assert not engine.order_manager.is_tracked("TEST-3")
     assert engine._is_weekend_gap is True
 
+
+@pytest.mark.asyncio
+async def test_anchor_update_on_full_sell_cycle(mock_broker, mock_sheet, config):
+    # Initial state: owned 10 shares
+    grid_state = GridState(
+        rows={
+            7: GridRow(row_index=7, status="OWNED:ORD-1", has_y=True, sell_price=105.0, buy_price=100.0, shares=10)
+        }
+    )
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.get_positions.return_value = {"TQQQ": 10}
+    mock_broker.get_wallet_balance.return_value = 50000.0
+    mock_broker.get_bid_ask.return_value = (100.0, 101.0)
+
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    engine.last_broker_shares = 10
+
+    # Tick where shares become 0
+    mock_broker.get_positions.return_value = {"TQQQ": 0}
+    # Need to update grid state so CB doesn't trip if we don't care about it here
+    # but _tick fetch_grid happens before CB.
+    grid_state.rows[7].has_y = False
+    grid_state.rows[7].shares = 0
+
+    await engine._tick()
+
+    # Should write fresh anchor ask to G7
+    mock_sheet.write_anchor_ask.assert_called_with(101.0)
+    assert engine.last_broker_shares == 0
+
+@pytest.mark.asyncio
+async def test_anchor_update_on_cancelled_buy(mock_broker, mock_sheet, config):
+    mock_broker.get_bid_ask.return_value = (102.0, 103.0)
+    engine = GridEngine(mock_broker, mock_sheet, config)
+
+    # Simulate a cancelled order for row 7 action BUY with 0 fill
+    result = OrderResult(order_id="ORD-7", status="cancelled", filled_qty=0)
+    engine.order_manager.track(7, OrderResult(order_id="ORD-7", status="submitted"), "BUY")
+
+    engine._handle_order_update(result)
+
+    # Give some time for the background task
+    await asyncio.sleep(0.1)
+
+    # Should write fresh anchor ask to G7
+    mock_sheet.write_anchor_ask.assert_called_with(103.0)
 
 @pytest.mark.asyncio
 async def test_no_anchor_write_if_already_working(mock_broker, mock_sheet, config):


### PR DESCRIPTION
Fixed two startup bugs in the GridEngine. 

The first fix ensures that the G7 anchor price in Google Sheets is only updated at the end of a position's lifecycle (full sell) or upon a failed entry (cancelled buy with no fill), preventing share quantity mismatches during active positions.

The second fix implements a robust startup sequence that waits up to 30 seconds for a confirmed non-zero price from the broker before proceeding with any trading logic or sheet writes. If the timeout is reached, the bot logs a critical error and exits gracefully.

Fixes #95

---
*PR created automatically by Jules for task [12271050580675077676](https://jules.google.com/task/12271050580675077676) started by @Wakeboardsam*