### PR TITLE
Fix share accounting and state management for rejected SELL orders

### DIFF
--- a/tqqq_bot_v5/config.yaml
+++ b/tqqq_bot_v5/config.yaml
@@ -1,5 +1,5 @@
 name: "TQQQ Grid Bot v5"
-version: "5.2.11"
+version: "5.2.12"
 slug: "tqqq_bot_v5"
 description: "Asyncio trading bot for TQQQ grid strategy on IBKR"
 arch:

--- a/tqqq_bot_v5/engine/engine.py
+++ b/tqqq_bot_v5/engine/engine.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import signal
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 import zoneinfo
 from typing import Optional
 
@@ -30,6 +30,7 @@ class GridEngine:
         self.last_fill_time: Optional[datetime] = None
         self.last_broker_shares = 0
         self.pending_status_updates: dict[int, str] = {}
+        self.row_cooldowns: dict[int, datetime] = {}
         self._shutdown_event = asyncio.Event()
         tz = zoneinfo.ZoneInfo("America/New_York")
         self._last_grid_regeneration = datetime.min.replace(tzinfo=tz)
@@ -372,6 +373,14 @@ class GridEngine:
 
                     in_window = row.row_index in window_range
 
+                    # Cooldown check
+                    if row.row_index in self.row_cooldowns:
+                        if datetime.now() < self.row_cooldowns[row.row_index]:
+                            logger.debug(f"Row {row.row_index} is in cooldown, skipping.")
+                            continue
+                        else:
+                            del self.row_cooldowns[row.row_index]
+
                     # Parse existing status to check for current orders and historical IDs
                     status_parts = row.status.split('|')
                     active_order_id = None
@@ -414,9 +423,11 @@ class GridEngine:
                                     self._update_row_status_in_memory(row.row_index, f"WORKING_SELL:{result.order_id}")
                                 elif result.status == 'error':
                                     self.order_manager.mark_cancelled(result.order_id)
-                                    if result.error_code == 10329:
-                                        logger.error(f"LOUD ALERT: Error 10329 for row {row.row_index}. Marking as FAILED.")
-                                        self._update_row_status_in_memory(row.row_index, "FAILED")
+                                    self.row_cooldowns[row.row_index] = datetime.now() + timedelta(minutes=5)
+                                    # Fix: Preserve Owned state for SELL
+                                    new_status = f"OWNED:{owned_id if owned_id else 0}"
+                                    logger.error(f"SELL order for row {row.row_index} failed (Code: {result.error_code}). Reverting to {new_status} and cooling down.")
+                                    self._update_row_status_in_memory(row.row_index, new_status)
                         elif row.row_index > distal_y:
                             if mismatch_active:
                                 logger.warning(f"Skipping BUY order for row {row.row_index} due to share mismatch")
@@ -458,9 +469,10 @@ class GridEngine:
                                     self._update_row_status_in_memory(row.row_index, f"WORKING_BUY:{result.order_id}")
                                 elif result.status == 'error':
                                     self.order_manager.mark_cancelled(result.order_id)
-                                    if result.error_code == 10329:
-                                        logger.error(f"LOUD ALERT: Error 10329 for row {row.row_index}. Marking as FAILED.")
-                                        self._update_row_status_in_memory(row.row_index, "FAILED")
+                                    self.row_cooldowns[row.row_index] = datetime.now() + timedelta(minutes=5)
+                                    # Fix: Revert to IDLE for BUY instead of FAILED
+                                    logger.error(f"BUY order for row {row.row_index} failed (Code: {result.error_code}). Reverting to IDLE and cooling down.")
+                                    self._update_row_status_in_memory(row.row_index, "IDLE")
                     else:
                         # Outside window
                         # Cancel any active orders for this row
@@ -536,7 +548,20 @@ class GridEngine:
                         logger.info("Anchor BUY cancelled/errored with 0 fill. Updating G7 anchor.")
                         asyncio.create_task(self._write_fresh_anchor_ask())
 
-                # We do NOT automatically revert status to IDLE/OWNED here
-                # because the next _tick will see the order is missing and decide what to do
-                # (e.g. replace it if it's still in window).
-                # UNLESS it was a 10329 error which we handle in _tick by marking FAILED.
+                if result.status == 'error':
+                    self.row_cooldowns[row_index] = datetime.now() + timedelta(minutes=5)
+                    # Revert status immediately so sheet doesn't show WORKING indefinitely if _tick is slow
+                    if action == 'SELL':
+                        # Try to find existing ID or use 0
+                        owned_id = "0"
+                        if self.grid_state and row_index in self.grid_state.rows:
+                            status = self.grid_state.rows[row_index].status
+                            if "OWNED:" in status:
+                                owned_id = status.split("OWNED:")[1].split("|")[0]
+                        new_status = f"OWNED:{owned_id}"
+                    else:
+                        new_status = "IDLE"
+
+                    logger.info(f"Setting {new_status} and cooldown for row {row_index} due to async order error.")
+                    self._update_row_status_in_memory(row_index, new_status)
+                    asyncio.create_task(self._sync_to_sheet())

--- a/tqqq_bot_v5/tests/test_error_handling.py
+++ b/tqqq_bot_v5/tests/test_error_handling.py
@@ -40,7 +40,7 @@ async def test_handle_error_10329(mock_broker, mock_sheet, config):
     })
     mock_sheet.fetch_grid.return_value = grid_state
 
-    # Simulate error 10329
+    # Simulate error 10329 on BUY
     mock_broker.place_limit_order.return_value = OrderResult(
         order_id="ORD-FAILED",
         status="error",
@@ -53,11 +53,36 @@ async def test_handle_error_10329(mock_broker, mock_sheet, config):
     with patch.object(GridState, 'distal_y_row', 7):
         await engine._tick()
 
-    # Should mark as FAILED
-    mock_sheet.update_row_status.assert_called_with(10, "FAILED")
-    # Should NOT be tracking the order (it should have been removed by mark_cancelled/mark_filled or similar)
-    # Actually mark_cancelled is called when status is error
+    # Should revert to IDLE (which it was already, so might not call update if it thinks it's the same,
+    # but engine._update_row_status_in_memory will queue it)
+    mock_sheet.update_row_status.assert_called_with(10, "IDLE")
     assert not engine.order_manager.is_tracked("ORD-FAILED")
+    assert 10 in engine.row_cooldowns
+
+@pytest.mark.asyncio
+async def test_handle_sell_error_preserves_owned(mock_broker, mock_sheet, config):
+    grid_state = GridState(rows={
+        10: GridRow(row_index=10, status="OWNED:999", has_y=True, sell_price=110.0, buy_price=105.0, shares=10)
+    })
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.get_positions.return_value = {"TQQQ": 10}
+
+    # Simulate error on SELL
+    mock_broker.place_limit_order.return_value = OrderResult(
+        order_id="ORD-SELL-FAILED",
+        status="error",
+        error_code=10329
+    )
+
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    # Row 10 is in window (distal_y=10, window=[7, 13])
+    with patch.object(GridState, 'distal_y_row', 10):
+        await engine._tick()
+
+    # Should revert to OWNED:999 (preserving the historical ID if possible, or OWNED:0)
+    # In our implementation it uses owned_id from the status string if found.
+    mock_sheet.update_row_status.assert_called_with(10, "OWNED:999")
+    assert 10 in engine.row_cooldowns
 
 @pytest.mark.asyncio
 async def test_skip_failed_level(mock_broker, mock_sheet, config):


### PR DESCRIPTION
Fixed a logic flaw where rejected SELL orders would mark rows as "FAILED", causing share count mismatches and tripping the circuit breaker. Introduced a 5-minute cooldown for rows with failed orders and ensured they revert to "OWNED" or "IDLE" status to maintain consistency with the broker's position.

Fixes #99

---
*PR created automatically by Jules for task [17574518598487434402](https://jules.google.com/task/17574518598487434402) started by @Wakeboardsam*