### PR TITLE
fix: bypass IBKR precautionary warnings in IBC config

### DIFF
--- a/tqqq_bot_v5/run.sh
+++ b/tqqq_bot_v5/run.sh
@@ -19,6 +19,7 @@ ReadOnlyApi=no
 OverrideTwsApiPort=${IBKR_PORT}
 AcceptIncomingConnectionAction=accept
 AcceptNonBrokerageAccountWarning=yes
+BypassOrderPrecautions=yes
 EOF
 echo "Starting Xvfb..."
 Xvfb :99 -ac -screen 0 1024x768x16 &


### PR DESCRIPTION
Fixes the recurring IBKR Error 10329 ("This order will be directly routed to OVERNIGHT. Restriction is specified in Precautionary Settings of Global Configuration/API") observed in the HomeAssistant Add-on logs.

When placing OND orders out-of-hours, IBKR raises a precautionary warning popup in TWS/Gateway. Since the bot runs headless inside a container without a user to manually dismiss the dialog, the API rejects the order. This change injects the standard IBC flag `BypassOrderPrecautions=yes` into the generated `/root/ibc/config.ini`, suppressing these dialogs and allowing unattended overnight execution to proceed.

---
*PR created automatically by Jules for task [11645792537335047559](https://jules.google.com/task/11645792537335047559) started by @Wakeboardsam*