### PR TITLE
Fix IBKR Error 10329 Headless Bypass

### DIFF
--- a/tqqq_bot_v5/brokers/ibkr/adapter.py
+++ b/tqqq_bot_v5/brokers/ibkr/adapter.py
@@ -194,6 +194,7 @@ class IBKRAdapter(BrokerBase):
         order = LimitOrder(action, qty, limit_price)
         order.tif = tif
         order.outsideRth = True
+        order.overridePercentageConstraints = True
 
         if order_id:
             order.orderId = int(order_id)

--- a/tqqq_bot_v5/run.sh
+++ b/tqqq_bot_v5/run.sh
@@ -20,7 +20,13 @@ OverrideTwsApiPort=${IBKR_PORT}
 AcceptIncomingConnectionAction=accept
 AcceptNonBrokerageAccountWarning=yes
 BypassOrderPrecautions=yes
+AllowBlindTrading=yes
 EOF
+echo "Injecting API bypass settings directly into jts.ini..."
+mkdir -p /root/Jts
+touch /root/Jts/jts.ini
+grep -q "BypassOrderPrecautions" /root/Jts/jts.ini || echo "BypassOrderPrecautions=true" >> /root/Jts/jts.ini
+grep -q "BypassRedirectOrderWarning" /root/Jts/jts.ini || echo "BypassRedirectOrderWarning=true" >> /root/Jts/jts.ini
 echo "Starting Xvfb..."
 Xvfb :99 -ac -screen 0 1024x768x16 &
 export DISPLAY=:99


### PR DESCRIPTION
This PR addresses IBKR Error 10329 (Precautionary Settings and Direct Routing block) which was rejecting TQQQ Grid Bot limit orders in a headless environment. 

Changes:
1.  **run.sh**:
    - Added `AllowBlindTrading=yes` to the IBC `config.ini`.
    - Added a script block to ensure `/root/Jts/jts.ini` exists and contains `BypassOrderPrecautions=true` and `BypassRedirectOrderWarning=true`. This ensures these GUI-based warnings are bypassed in the headless Home Assistant Add-on environment.
2.  **tqqq_bot_v5/brokers/ibkr/adapter.py**:
    - In `place_limit_order`, added `order.overridePercentageConstraints = True`. This prevents the IBKR API from rejecting orders that are placed far from the current market price, which is common in grid trading strategies.

These changes allow the bot to operate autonomously without requiring manual interaction with the IBKR Gateway GUI.

Fixes #102

---
*PR created automatically by Jules for task [1337122931461273279](https://jules.google.com/task/1337122931461273279) started by @Wakeboardsam*