### PR TITLE
Implement encrypted IBKR settings injection in HA add-on startup

### DIFF
--- a/tqqq_bot_v5/run.sh
+++ b/tqqq_bot_v5/run.sh
@@ -27,6 +27,41 @@ mkdir -p /root/Jts
 touch /root/Jts/jts.ini
 grep -q "BypassOrderPrecautions" /root/Jts/jts.ini || echo "BypassOrderPrecautions=true" >> /root/Jts/jts.ini
 grep -q "BypassRedirectOrderWarning" /root/Jts/jts.ini || echo "BypassRedirectOrderWarning=true" >> /root/Jts/jts.ini
+
+# Encrypted settings injection
+SETTINGS_FILE="/app/tws.20260405.222111.ibgzenc"
+PROFILE_ID="bfmeflenhmfhdgmnkkccpggjcdgjdkanjkgfdgca"
+TWS_MAJOR_VRSN=1019
+
+inject_settings() {
+    local target_dir=$1
+    local target_file="$target_dir/$(basename "$SETTINGS_FILE")"
+
+    mkdir -p "$target_dir"
+
+    if [ -f "$target_file" ]; then
+        echo "Backing up existing settings file at $target_file"
+        mv "$target_file" "${target_file}.bak_$(date +%Y%m%d%H%M%S)"
+    fi
+
+    echo "Copying encrypted settings to $target_dir"
+    cp "$SETTINGS_FILE" "$target_file"
+    chmod 644 "$target_file"
+}
+
+if [ -f "$SETTINGS_FILE" ]; then
+    echo "Preparing encrypted IBKR settings injection..."
+    echo "Found encrypted settings file: $SETTINGS_FILE"
+    echo "WARNING: Source settings are from Gateway 1044, but container is using $TWS_MAJOR_VRSN."
+
+    # Inject into candidate locations
+    inject_settings "/root/Jts"
+    inject_settings "/root/Jts/$TWS_MAJOR_VRSN"
+    inject_settings "/root/Jts/$TWS_MAJOR_VRSN/$PROFILE_ID"
+else
+    echo "Encrypted settings file NOT found at $SETTINGS_FILE. Skipping injection."
+fi
+
 echo "Starting Xvfb..."
 Xvfb :99 -ac -screen 0 1024x768x16 &
 export DISPLAY=:99
@@ -37,6 +72,24 @@ export IBC_PATH=/opt/ibc
 /opt/ibc/gatewaystart.sh -inline < /dev/null &
 echo "Waiting 30 seconds for Gateway to initialize..."
 sleep 30
+
+# Post-startup detection for new profiles
+if [ -f "$SETTINGS_FILE" ]; then
+    echo "Scanning for newly created profile directories..."
+    for d in /root/Jts/$TWS_MAJOR_VRSN/*/; do
+        [ -d "$d" ] || continue
+        dir_name=$(basename "$d")
+        # Profile directories are typically long alphanumeric strings
+        if [ ${#dir_name} -gt 20 ]; then
+            if [ ! -f "$d/$(basename "$SETTINGS_FILE")" ]; then
+                echo "Detected new/missing profile directory: $dir_name. Injecting settings..."
+                inject_settings "$d"
+                echo "Injection complete for $dir_name. A restart may be required if this was not the target profile."
+            fi
+        fi
+    done
+fi
+
 echo "=== IBC DIAGNOSTIC LOGS ==="
 cat /root/ibc/logs/*.txt 2>/dev/null || echo "No IBC logs found."
 echo "==========================="


### PR DESCRIPTION
This change modifies the Home Assistant add-on startup script (`tqqq_bot_v5/run.sh`) to automatically inject an encrypted IBKR Gateway settings file into the correct runtime locations. This is required to preserve overnight-routing approvals and bypass Error 10329 in headless environments.

Key improvements:
1. **Multi-layered Injection**: The settings file is copied to the base Jts dir, the versioned dir (1019), and a known profile dir before startup.
2. **Dynamic Profile Detection**: After Gateway starts, the script scans for any newly created profile directories and injects the settings file there as well.
3. **Safety**: Existing settings are backed up before being replaced, and permissions are set correctly.
4. **Visibility**: Detailed logs are provided for each step, including a warning about the 1044 vs 1019 version mismatch.
5. **Robustness**: Uses `mkdir -p` and robust path handling to ensure the injection succeeds even if the directory structure is not fully present at start.

All 82 existing tests passed.

Fixes #109

---
*PR created automatically by Jules for task [12640362825097143286](https://jules.google.com/task/12640362825097143286) started by @Wakeboardsam*