### PR TITLE
Apply anchor_buy_offset for anchor acquisition

### DIFF
--- a/tqqq_bot_v5/engine/engine.py
+++ b/tqqq_bot_v5/engine/engine.py
@@ -477,8 +477,12 @@ class GridEngine:
                                         if r_index == 7:
                                             live_qty = o.get('qty')
                                             live_price = o.get('limit_price')
-                                            if live_qty != row.shares or live_price != row.buy_price:
-                                                logger.warning(f"Anchor order mismatch detected for row 7: live order qty/price={live_qty}@{live_price}, sheet qty/price={row.shares}@{row.buy_price}")
+                                            expected_buy_price = row.buy_price
+                                            if distal_y == 0:
+                                                expected_buy_price += self.config.anchor_buy_offset
+
+                                            if live_qty != row.shares or abs(live_price - expected_buy_price) > 0.001:
+                                                logger.warning(f"Anchor order mismatch detected for row 7: live order qty/price={live_qty}@{live_price}, expected qty/price={row.shares}@{expected_buy_price}")
                                                 # We skip further processing for this row in this tick (do not auto-cancel-replace yet)
                                                 break # Will continue with the outer loop since the outer `if not self.order_manager.has_open_buy` will be false and we do nothing else
 
@@ -488,6 +492,7 @@ class GridEngine:
 
                                 if row.row_index == 7 and distal_y == 0:
                                     # Anchor acquisition!
+                                    buy_price += self.config.anchor_buy_offset
                                     logger.info("Anchor acquisition condition met for row 7")
                                     # We check spread using a fresh ask but we DO NOT write it to G7 here.
                                     # We use the existing buy_price from the sheet (calculated from current G7).
@@ -495,7 +500,7 @@ class GridEngine:
                                     if self.spread_guard.is_too_wide(bid, ask):
                                         continue
 
-                                    logger.info(f"Placing anchor BUY for row 7 at {buy_price} (sheet-derived)")
+                                    logger.info(f"Placing anchor BUY for row 7 at {buy_price} (including offset {self.config.anchor_buy_offset})")
                                 else:
                                     logger.info(f"Placing missing BUY for empty row {row.row_index}")
 

--- a/tqqq_bot_v5/tests/test_engine.py
+++ b/tqqq_bot_v5/tests/test_engine.py
@@ -174,10 +174,57 @@ async def test_anchor_acquisition(mock_broker, mock_sheet, config):
     # Bug 1 Fix: Should NOT write anchor ask to G7 on buy placement
     mock_sheet.write_anchor_ask.assert_not_called()
 
-    # Should place buy order at price from sheet
+    # Should place buy order at price from sheet + offset
     mock_broker.place_limit_order.assert_any_call(
-        ticker="TQQQ", action="BUY", qty=10, limit_price=100.0, on_update=engine._handle_order_update, order_id="ORD-123"
+        ticker="TQQQ", action="BUY", qty=10, limit_price=100.05, on_update=engine._handle_order_update, order_id="ORD-123"
     )
+
+@pytest.mark.asyncio
+async def test_non_anchor_buy_no_offset(mock_broker, mock_sheet, config):
+    # distal_y == 7 condition, so row 8 is NOT an anchor buy
+    grid_state = GridState(
+        rows={
+            7: GridRow(row_index=7, status="OWNED:OLD", has_y=True, sell_price=105.0, buy_price=100.0, shares=10),
+            8: GridRow(row_index=8, status="IDLE", has_y=False, sell_price=110.0, buy_price=105.0, shares=10)
+        }
+    )
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.get_position_snapshot.return_value = PositionSnapshot(is_ready=True, positions={"TQQQ": 10})
+    config.anchor_buy_offset = 0.05
+
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    await engine._tick()
+
+    # Should place buy order for row 8 at exact sheet price
+    mock_broker.place_limit_order.assert_any_call(
+        ticker="TQQQ", action="BUY", qty=10, limit_price=105.0, on_update=engine._handle_order_update, order_id=mock_broker.get_next_order_id.return_value
+    )
+
+@pytest.mark.asyncio
+async def test_protective_reconciliation_with_offset(mock_broker, mock_sheet, config):
+    # distal_y == 0
+    grid_state = GridState(
+        rows={
+            7: GridRow(row_index=7, status="WORKING_BUY:ORD-123", has_y=False, sell_price=105.0, buy_price=100.0, shares=10),
+        }
+    )
+    mock_sheet.fetch_grid.return_value = grid_state
+    mock_broker.get_position_snapshot.return_value = PositionSnapshot(is_ready=True, positions={"TQQQ": 0})
+    config.anchor_buy_offset = 0.05
+
+    # Live order has price 100.05 (100.0 + 0.05)
+    mock_broker.get_open_orders.return_value = [{'order_id': 'ORD-123', 'limit_price': 100.05, 'qty': 10, 'action': 'BUY'}]
+
+    engine = GridEngine(mock_broker, mock_sheet, config)
+    engine.order_manager.track(7, OrderResult(order_id="ORD-123", status="submitted"), "BUY")
+
+    await engine._tick()
+
+    # Should NOT log a warning because 100.05 is the expected price including offset
+    mock_sheet.log_error.assert_not_called()
+    # verify it didn't call place_limit_order again
+    buy_calls = [call for call in mock_broker.place_limit_order.call_args_list if call.kwargs.get('action') == 'BUY']
+    assert len(buy_calls) == 0
 
 @pytest.mark.asyncio
 async def test_no_anchor_write_if_owned(mock_broker, mock_sheet, config):


### PR DESCRIPTION
Implement anchor_buy_offset for row 7 BUY orders during anchor acquisition. This allows the bot to place more aggressive orders for the initial anchor without affecting sheet logic or formulas. Includes updated protective reconciliation and comprehensive unit tests.

Fixes #113

---
*PR created automatically by Jules for task [16299110993745099476](https://jules.google.com/task/16299110993745099476) started by @Wakeboardsam*