### PR TITLE
Implement IBKR degraded state watchdog to recover stuck account sync

### DIFF
--- a/tqqq_bot_v5/brokers/ibkr/adapter.py
+++ b/tqqq_bot_v5/brokers/ibkr/adapter.py
@@ -25,6 +25,8 @@ class IBKRAdapter(BrokerBase):
         self._last_error: dict[int, tuple[int, str]] = {}  # reqId -> (errorCode, errorString)
         self._disconnect_time: Optional[datetime] = None
         self._broker_state_ready = False
+        self._connected_not_ready_since: Optional[datetime] = None
+        self._degraded_reconnect_attempted: bool = False
 
         # Subscribe to order status and execution events
         self.ib.orderStatusEvent += self._on_order_status
@@ -40,18 +42,93 @@ class IBKRAdapter(BrokerBase):
         connected = await async_connect(self.ib, self.host, self.port, self.client_id)
         if connected:
             self.ib.reqMarketDataType(3)
+            self._connected_not_ready_since = datetime.now()
+            self._degraded_reconnect_attempted = False
         return connected
 
     async def disconnect(self):
         self._broker_state_ready = False
+        self._connected_not_ready_since = None
+        self._degraded_reconnect_attempted = False
         self.ib.disconnect()
 
     async def is_connected(self) -> bool:
         return self.ib.isConnected()
 
+    async def _check_broker_state_health(self):
+        if self._broker_state_ready:
+            return
+
+        # Flag indicating if we successfully validated state
+        is_state_valid = False
+
+        if not self.ib.accountValues():
+            # Missing account values
+            logger.info("IBKR transport connected but accountValues is empty.")
+        else:
+            # Account values exist. Try to fetch positions to ensure sync is not stuck.
+            # It's fine if the result is empty, as long as it doesn't throw or timeout.
+            try:
+                await asyncio.wait_for(self.get_positions(), timeout=10.0)
+                is_state_valid = True
+            except Exception as e:
+                logger.warning(f"Positions fetch timed out or failed during health check: {e}. Sync is stuck.")
+
+        if is_state_valid:
+            # Successfully accessed positions and account values
+            self._broker_state_ready = True
+            self._connected_not_ready_since = None
+            self._degraded_reconnect_attempted = False
+            logger.info("Broker state transitioned to READY (accountValues populated and positions synced).")
+            return
+
+        # Account not ready yet.
+        if self._connected_not_ready_since is None:
+            self._connected_not_ready_since = datetime.now()
+            logger.info("Entering degraded recovery watchdog: account state not ready.")
+
+        time_waiting = datetime.now() - self._connected_not_ready_since
+        if time_waiting > timedelta(minutes=2):
+            logger.warning(f"Degraded timeout exceeded: transport connected but account state not ready for {time_waiting}.")
+            if not self._degraded_reconnect_attempted:
+                logger.info("Attempting full IB object reset/reconnect due to degraded state...")
+
+                try:
+                    self.ib.disconnect()
+                except Exception:
+                    pass
+
+                self.ib = IB()
+                self._broker_state_ready = False
+                self.ib.orderStatusEvent += self._on_order_status
+                self.ib.execDetailsEvent += self._on_exec_details
+                self.ib.errorEvent += self._on_error
+
+                try:
+                    connected = await async_connect(self.ib, self.host, self.port, self.client_id)
+                    if connected:
+                        logger.info("Degraded state recovery: successfully reconnected with fresh IB object. Giving account sync 2 minutes.")
+                        self.ib.reqMarketDataType(3)
+                        self._connected_not_ready_since = datetime.now()
+                        self._degraded_reconnect_attempted = True
+                    else:
+                        logger.error("Degraded state recovery reconnect failed.")
+                except Exception as e:
+                    logger.error(f"Degraded state recovery reconnect exception: {e}")
+            else:
+                logger.critical("Degraded state watchdog: reconnect failed to restore account state. Triggering full container restart via SIGTERM to PID 1.")
+                try:
+                    os.kill(1, signal.SIGTERM)
+                except Exception as e:
+                    logger.error(f"Failed to send SIGTERM to PID 1: {e}")
+                raise ConnectionError("Degraded state watchdog triggered container restart after failing to recover account state.")
+        else:
+            logger.info(f"Waiting for account sync (elapsed: {time_waiting})...")
+
     async def ensure_connected(self):
         if await self.is_connected():
             self._disconnect_time = None
+            await self._check_broker_state_health()
             return
 
         self._broker_state_ready = False
@@ -84,6 +161,8 @@ class IBKRAdapter(BrokerBase):
                 logger.info("Watchdog Stage 1 successfully reconnected.")
                 self.ib.reqMarketDataType(3)
                 self._disconnect_time = None
+                self._connected_not_ready_since = datetime.now()
+                self._degraded_reconnect_attempted = False
                 return
         except Exception as e:
             logger.error(f"Stage 1 reconnect failed: {e}")
@@ -110,6 +189,8 @@ class IBKRAdapter(BrokerBase):
                 logger.info("Watchdog Stage 2 successfully reconnected with fresh IB object.")
                 self.ib.reqMarketDataType(3)
                 self._disconnect_time = None
+                self._connected_not_ready_since = datetime.now()
+                self._degraded_reconnect_attempted = False
                 return
         except Exception as e:
             logger.error(f"Stage 2 reconnect failed: {e}")
@@ -401,12 +482,7 @@ class IBKRAdapter(BrokerBase):
 
     async def get_position_snapshot(self) -> PositionSnapshot:
         if not self._broker_state_ready:
-            # Heuristic: accountValues() is almost always populated immediately upon account sync
-            if self.ib.accountValues():
-                self._broker_state_ready = True
-                logger.info("Broker state transitioned to READY (accountValues populated).")
-            else:
-                return PositionSnapshot(is_ready=False, positions={})
+            return PositionSnapshot(is_ready=False, positions={})
 
         positions = await self.get_positions()
         return PositionSnapshot(is_ready=True, positions=positions)

--- a/tqqq_bot_v5/brokers/ibkr/adapter.py
+++ b/tqqq_bot_v5/brokers/ibkr/adapter.py
@@ -66,16 +66,17 @@ class IBKRAdapter(BrokerBase):
             # Missing account values
             logger.info("IBKR transport connected but accountValues is empty.")
         else:
-            # Account values exist. Try to fetch positions to ensure sync is not stuck.
-            # It's fine if the result is empty, as long as it doesn't throw or timeout.
+            # Account values exist, but we must explicitly prove the connection isn't returning
+            # an empty wrapper cache. reqPositionsAsync() forces a live fetch from the broker
+            # and only completes when the positionEnd marker is received.
             try:
-                await asyncio.wait_for(self.get_positions(), timeout=10.0)
+                await asyncio.wait_for(self.ib.reqPositionsAsync(), timeout=10.0)
                 is_state_valid = True
             except Exception as e:
-                logger.warning(f"Positions fetch timed out or failed during health check: {e}. Sync is stuck.")
+                logger.warning(f"Active positions fetch timed out or failed during health check: {e}. Sync is stuck.")
 
         if is_state_valid:
-            # Successfully accessed positions and account values
+            # Successfully forced a live fetch and got account values
             self._broker_state_ready = True
             self._connected_not_ready_since = None
             self._degraded_reconnect_attempted = False

--- a/tqqq_bot_v5/tests/test_ibkr_adapter.py
+++ b/tqqq_bot_v5/tests/test_ibkr_adapter.py
@@ -408,3 +408,109 @@ async def test_ibkr_reconnect_clears_state_and_readiness():
     # Test that get_position_snapshot now correctly returns is_ready=False
     snapshot = await adapter.get_position_snapshot()
     assert snapshot.is_ready is False
+
+@pytest.mark.asyncio
+async def test_degraded_state_timer_starts(mock_ib):
+    adapter = IBKRAdapter("127.0.0.1", 7497, 1, False)
+    adapter.ib = mock_ib
+    adapter.ib.isConnected = MagicMock(return_value=True)
+    adapter.ib.accountValues = MagicMock(return_value=[]) # Empty -> not ready
+    adapter._broker_state_ready = False
+
+    assert adapter._connected_not_ready_since is None
+
+    await adapter.ensure_connected()
+
+    assert adapter._connected_not_ready_since is not None
+    assert adapter._broker_state_ready is False
+
+@pytest.mark.asyncio
+async def test_degraded_state_reconnects_after_timeout(mock_ib):
+    adapter = IBKRAdapter("127.0.0.1", 7497, 1, False)
+    adapter.ib = mock_ib
+    adapter.ib.isConnected = MagicMock(return_value=True)
+    adapter.ib.accountValues = MagicMock(return_value=[]) # Empty -> not ready
+    adapter._broker_state_ready = False
+
+    # Set timer back 3 minutes to trigger timeout
+    adapter._connected_not_ready_since = datetime.datetime.now() - datetime.timedelta(minutes=3)
+    adapter._degraded_reconnect_attempted = False
+
+    # Mock connectAsync
+    adapter.ib.connectAsync = AsyncMock()
+    adapter.ib.disconnect = MagicMock()
+    adapter.ib.orderStatusEvent = MagicMock()
+    adapter.ib.execDetailsEvent = MagicMock()
+    adapter.ib.errorEvent = MagicMock()
+
+    with patch('brokers.ibkr.adapter.IB', return_value=adapter.ib):
+        await adapter.ensure_connected()
+
+    # Verify we attempted a reconnect
+    assert adapter._degraded_reconnect_attempted is True
+    adapter.ib.connectAsync.assert_awaited() # async_connect uses connectAsync under the hood
+    # Timer should be reset
+    assert (datetime.datetime.now() - adapter._connected_not_ready_since).total_seconds() < 5
+
+@pytest.mark.asyncio
+async def test_degraded_state_escalates_to_sigterm(mock_ib):
+    adapter = IBKRAdapter("127.0.0.1", 7497, 1, False)
+    adapter.ib = mock_ib
+    adapter.ib.isConnected = MagicMock(return_value=True)
+    adapter.ib.accountValues = MagicMock(return_value=[]) # Empty -> not ready
+    adapter._broker_state_ready = False
+
+    # Set timer back 3 minutes to trigger timeout
+    adapter._connected_not_ready_since = datetime.datetime.now() - datetime.timedelta(minutes=3)
+    # We already tried reconnecting
+    adapter._degraded_reconnect_attempted = True
+
+    with patch('os.kill') as mock_kill:
+        with pytest.raises(ConnectionError, match="Degraded state watchdog triggered"):
+            await adapter.ensure_connected()
+
+        # Verify SIGTERM sent to PID 1
+        import signal
+        mock_kill.assert_called_once_with(1, signal.SIGTERM)
+
+@pytest.mark.asyncio
+async def test_normal_reconnect_transitions_to_ready(mock_ib):
+    adapter = IBKRAdapter("127.0.0.1", 7497, 1, False)
+    adapter.ib = mock_ib
+    adapter.ib.isConnected = MagicMock(return_value=True)
+    # Account values are present
+    adapter.ib.accountValues = MagicMock(return_value=[MagicMock()])
+    # Positions succeed
+    adapter.get_positions = AsyncMock(return_value={})
+
+    adapter._broker_state_ready = False
+    adapter._connected_not_ready_since = datetime.datetime.now()
+    adapter._degraded_reconnect_attempted = True
+
+    await adapter.ensure_connected()
+
+    assert adapter._broker_state_ready is True
+    assert adapter._connected_not_ready_since is None
+    assert adapter._degraded_reconnect_attempted is False
+
+@pytest.mark.asyncio
+async def test_positions_timeout_keeps_state_not_ready(mock_ib):
+    adapter = IBKRAdapter("127.0.0.1", 7497, 1, False)
+    adapter.ib = mock_ib
+    adapter.ib.isConnected = MagicMock(return_value=True)
+    # Account values are present
+    adapter.ib.accountValues = MagicMock(return_value=[MagicMock()])
+
+    # Positions timeout
+    adapter.get_positions = AsyncMock()
+
+    adapter._broker_state_ready = False
+    adapter._connected_not_ready_since = None
+
+    # Since timeout is 10s we can use patch/mock to make wait_for fail faster in test,
+    # but actual wait_for raises TimeoutError, which we catch. Let's just mock wait_for to raise TimeoutError.
+    adapter.get_positions.side_effect = TimeoutError("timeout")
+    await adapter.ensure_connected()
+
+    assert adapter._broker_state_ready is False
+    assert adapter._connected_not_ready_since is not None

--- a/tqqq_bot_v5/tests/test_ibkr_adapter.py
+++ b/tqqq_bot_v5/tests/test_ibkr_adapter.py
@@ -480,8 +480,8 @@ async def test_normal_reconnect_transitions_to_ready(mock_ib):
     adapter.ib.isConnected = MagicMock(return_value=True)
     # Account values are present
     adapter.ib.accountValues = MagicMock(return_value=[MagicMock()])
-    # Positions succeed
-    adapter.get_positions = AsyncMock(return_value={})
+    # Positions sync succeeds explicitly
+    adapter.ib.reqPositionsAsync = AsyncMock(return_value=[])
 
     adapter._broker_state_ready = False
     adapter._connected_not_ready_since = datetime.datetime.now()
@@ -501,15 +501,12 @@ async def test_positions_timeout_keeps_state_not_ready(mock_ib):
     # Account values are present
     adapter.ib.accountValues = MagicMock(return_value=[MagicMock()])
 
-    # Positions timeout
-    adapter.get_positions = AsyncMock()
+    # Explicit active sync timeout
+    adapter.ib.reqPositionsAsync = AsyncMock(side_effect=TimeoutError("timeout"))
 
     adapter._broker_state_ready = False
     adapter._connected_not_ready_since = None
 
-    # Since timeout is 10s we can use patch/mock to make wait_for fail faster in test,
-    # but actual wait_for raises TimeoutError, which we catch. Let's just mock wait_for to raise TimeoutError.
-    adapter.get_positions.side_effect = TimeoutError("timeout")
     await adapter.ensure_connected()
 
     assert adapter._broker_state_ready is False


### PR DESCRIPTION
This PR addresses an issue where the IBKR Gateway could recover its socket connection, but fail to synchronize account information (e.g., account values, portfolio, positions), leaving the bot in a 'half-connected' state where it was able to update health logs but not trade.

To fix this, the IBKR adapter now separates the "API transport connected" state from the "broker/account state ready" state. We implement a secondary watchdog that starts a 2-minute timer upon socket connection. If the account values and positions cannot be synced within this timeout, the bot attempts a full `IB()` object recreation and reconnect. If that fails to restore sync after another 2 minutes, the watchdog forcefully restarts the add-on container via `SIGTERM` to PID 1.

The existing 15-minute watchdog responsible for nightly socket downtime remains in place.

Tests have been added to verify normal transitions to ready, timeout handling, retry behavior, and terminal SIGTERM escalation.

---
*PR created automatically by Jules for task [7424667253378834405](https://jules.google.com/task/7424667253378834405) started by @Wakeboardsam*